### PR TITLE
Add Dockerfile for CI usage

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,31 @@
+# Step one: build file-integrity-operator
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+
+WORKDIR /go/src/github.com/openshift/file-integrity-operator
+
+ARG ARG_GOPROXY="https://proxy.golang.org"
+ARG ARG_GOSUMDB="sum.golang.org"
+
+ENV GOPROXY=$ARG_GOPROXY
+ENV GOSUMDB=$ARG_GOSUMDB
+
+COPY . .
+
+RUN make
+
+# Step two: containerize file-integrity-operator
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ENV OPERATOR=/usr/local/bin/file-integrity-operator \
+    USER_UID=1001 \
+    USER_NAME=file-integrity-operator
+
+# install operator binary
+COPY --from=builder /go/src/github.com/openshift/file-integrity-operator/build/_output/bin/file-integrity-operator ${OPERATOR}
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}


### PR DESCRIPTION
Similarly to the one we added for the compliance-operator, this adds a
dockerfile for CI use only.