### PR TITLE
Up timeout for cleanup and wait

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -20,11 +20,11 @@ import (
 )
 
 const (
-	pollInterval         = 2 * time.Second
-	timeout              = time.Second * 120
+	pollInterval         = time.Second * 2
 	retryInterval        = time.Second * 5
+	timeout              = time.Minute * 10
 	cleanupRetryInterval = time.Second * 1
-	cleanupTimeout       = time.Second * 5
+	cleanupTimeout       = time.Minute * 5
 )
 
 func cleanUp(t *testing.T, namespace string) func() error {


### PR DESCRIPTION
Currently we have a waiting time of 2 minutes for the creation of stuff
(e.g. the operator itself). This might be too short in cases where we
need to fetch the image for the first time. So, similarly as with the
compliance-operator, lets up this to 10min.