### PR TITLE
Add FileIntegrityStatus controller

### DIFF
--- a/deploy/crds/file-integrity.openshift.io_fileintegrities_crd.yaml
+++ b/deploy/crds/file-integrity.openshift.io_fileintegrities_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: fileintegrities.file-integrity.openshift.io
@@ -10,49 +10,56 @@ spec:
     plural: fileintegrities
     singular: fileintegrity
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: FileIntegrity is the Schema for the fileintegrities API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: FileIntegritySpec defines the desired state of FileIntegrity
+          properties:
+            config:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+              type: object
+          required:
+          - config
+          type: object
+        status:
+          description: FileIntegrityStatus defines the observed state of FileIntegrity
+          properties:
+            phase:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: FileIntegrity is the Schema for the fileintegrities API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: FileIntegritySpec defines the desired state of FileIntegrity
-            properties:
-              config:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "operator-sdk generate k8s" to regenerate code after
-                  modifying this file Add custom validation using kubebuilder tags:
-                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-                properties:
-                  key:
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                type: object
-            required:
-            - config
-            type: object
-          status:
-            description: FileIntegrityStatus defines the observed state of FileIntegrity
-            type: object
-        type: object
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
+++ b/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
@@ -7,6 +7,14 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+type FileIntegrityStatusPhase string
+
+const (
+	PhaseInitializing FileIntegrityStatusPhase = "Initializing"
+	PhaseActive       FileIntegrityStatusPhase = "Active"
+	PhasePending      FileIntegrityStatusPhase = "Pending"
+)
+
 // FileIntegritySpec defines the desired state of FileIntegrity
 // +k8s:openapi-gen=true
 type FileIntegritySpec struct {
@@ -30,6 +38,7 @@ type FileIntegrityStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+	Phase FileIntegrityStatusPhase `json:"phase,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/fileintegrity/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fileintegrity/v1alpha1/zz_generated.deepcopy.go
@@ -56,7 +56,7 @@ func (in *FileIntegrityConfig) DeepCopy() *FileIntegrityConfig {
 func (in *FileIntegrityList) DeepCopyInto(out *FileIntegrityList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]FileIntegrity, len(*in))

--- a/pkg/apis/fileintegrity/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/fileintegrity/v1alpha1/zz_generated.openapi.go
@@ -11,10 +11,10 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"./pkg/apis/fileintegrity/v1alpha1.FileIntegrity":       schema_pkg_apis_fileintegrity_v1alpha1_FileIntegrity(ref),
-		"./pkg/apis/fileintegrity/v1alpha1.FileIntegrityConfig": schema_pkg_apis_fileintegrity_v1alpha1_FileIntegrityConfig(ref),
-		"./pkg/apis/fileintegrity/v1alpha1.FileIntegritySpec":   schema_pkg_apis_fileintegrity_v1alpha1_FileIntegritySpec(ref),
-		"./pkg/apis/fileintegrity/v1alpha1.FileIntegrityStatus": schema_pkg_apis_fileintegrity_v1alpha1_FileIntegrityStatus(ref),
+		"github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1.FileIntegrity":       schema_pkg_apis_fileintegrity_v1alpha1_FileIntegrity(ref),
+		"github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1.FileIntegrityConfig": schema_pkg_apis_fileintegrity_v1alpha1_FileIntegrityConfig(ref),
+		"github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1.FileIntegritySpec":   schema_pkg_apis_fileintegrity_v1alpha1_FileIntegritySpec(ref),
+		"github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1.FileIntegrityStatus": schema_pkg_apis_fileintegrity_v1alpha1_FileIntegrityStatus(ref),
 	}
 }
 
@@ -46,19 +46,19 @@ func schema_pkg_apis_fileintegrity_v1alpha1_FileIntegrity(ref common.ReferenceCa
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/fileintegrity/v1alpha1.FileIntegritySpec"),
+							Ref: ref("github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1.FileIntegritySpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/fileintegrity/v1alpha1.FileIntegrityStatus"),
+							Ref: ref("github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1.FileIntegrityStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/fileintegrity/v1alpha1.FileIntegritySpec", "./pkg/apis/fileintegrity/v1alpha1.FileIntegrityStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1.FileIntegritySpec", "github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1.FileIntegrityStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -103,7 +103,7 @@ func schema_pkg_apis_fileintegrity_v1alpha1_FileIntegritySpec(ref common.Referen
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html",
-							Ref:         ref("./pkg/apis/fileintegrity/v1alpha1.FileIntegrityConfig"),
+							Ref:         ref("github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1.FileIntegrityConfig"),
 						},
 					},
 				},
@@ -111,7 +111,7 @@ func schema_pkg_apis_fileintegrity_v1alpha1_FileIntegritySpec(ref common.Referen
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/fileintegrity/v1alpha1.FileIntegrityConfig"},
+			"github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1.FileIntegrityConfig"},
 	}
 }
 
@@ -121,6 +121,15 @@ func schema_pkg_apis_fileintegrity_v1alpha1_FileIntegrityStatus(ref common.Refer
 			SchemaProps: spec.SchemaProps{
 				Description: "FileIntegrityStatus defines the observed state of FileIntegrity",
 				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"phase": {
+						SchemaProps: spec.SchemaProps{
+							Description: "INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -1,0 +1,14 @@
+package common
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func DaemonSetIsReady(ds *appsv1.DaemonSet) bool {
+	return ds.Status.DesiredNumberScheduled == ds.Status.NumberAvailable
+}
+
+func DaemonSetIsUpdating(ds *appsv1.DaemonSet) bool {
+	return ds.Status.UpdatedNumberScheduled > 0 &&
+		(ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled || ds.Status.NumberUnavailable > 0)
+}

--- a/pkg/controller/add_status.go
+++ b/pkg/controller/add_status.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/openshift/file-integrity-operator/pkg/controller/status"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, status.Add)
+}

--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -119,7 +119,7 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, err
 	}
 	// not ready, requeue
-	if !daemonSetIsReady(reinitDS) {
+	if !common.DaemonSetIsReady(reinitDS) {
 		reqLogger.Info("DBG: requeue of DS")
 		return reconcile.Result{RequeueAfter: time.Duration(5 * time.Second)}, nil // guessing on 5 seconds as acceptable requeue rate
 	}
@@ -165,9 +165,4 @@ func triggerDaemonSetRollout(c client.Client, ds *appsv1.DaemonSet) error {
 	}
 	dscpy.Spec.Template.Annotations["fileintegrity.openshift.io/restart-"+fmt.Sprintf("%d", time.Now().Unix())] = ""
 	return c.Update(context.TODO(), dscpy)
-}
-
-// this method to check ready is used in some of the Origin e2e testing - is it accurate?
-func daemonSetIsReady(ds *appsv1.DaemonSet) bool {
-	return ds.Status.DesiredNumberScheduled == ds.Status.NumberAvailable
 }

--- a/pkg/controller/fileintegrity/config.go
+++ b/pkg/controller/fileintegrity/config.go
@@ -27,9 +27,19 @@ func prepareAideConf(in string) (string, error) {
 		} else if strings.HasPrefix(line, "report_url=file") {
 			conv = conv + "report_url=file:@@{LOGDIR}/aide.log\n"
 		} else if strings.HasPrefix(line, "/") {
-			conv = conv + "/hostroot" + line + "\n"
+			if strings.HasPrefix(line, "/hostroot") {
+				// line already has /hostroot, skip prepending it
+				conv = conv + line + "\n"
+			} else {
+				conv = conv + "/hostroot" + line + "\n"
+			}
 		} else if strings.HasPrefix(line, "!/") {
-			conv = conv + "!/hostroot" + line[1:] + "\n"
+			if strings.HasPrefix(line, "!/hostroot") {
+				// line already has !/hostroot, skip prepending it
+				conv = conv + line + "\n"
+			} else {
+				conv = conv + "!/hostroot" + line[1:] + "\n"
+			}
 		} else {
 			if line != "\n" {
 				conv = conv + line + "\n"

--- a/pkg/controller/status/status_controller.go
+++ b/pkg/controller/status/status_controller.go
@@ -1,0 +1,152 @@
+package status
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	fileintegrityv1alpha1 "github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1"
+	"github.com/openshift/file-integrity-operator/pkg/common"
+)
+
+var log = logf.Log.WithName("controller_status")
+var statusRequeue = time.Second * 30
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new FileIntegrity Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileFileIntegrityStatus{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("status-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource FileIntegrity
+	err = c.Watch(&source.Kind{Type: &fileintegrityv1alpha1.FileIntegrity{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+	// XXX also watch for configmaps, init daemonset
+
+	return nil
+}
+
+// blank assignment to verify that ReconcileFileIntegrity implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileFileIntegrityStatus{}
+
+// ReconcileFileIntegrity reconciles a FileIntegrity object
+type ReconcileFileIntegrityStatus struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+// Reconcile handles the creation and update of configMaps as well as the initial daemonSets for the AIDE pods.
+func (r *ReconcileFileIntegrityStatus) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("reconciling FileIntegrityStatus")
+
+	// Fetch the FileIntegrity instance
+	instance := &fileintegrityv1alpha1.FileIntegrity{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if kerr.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// first check is for the reinit daemonset, when this exists at all we are in an initialization phase.
+	reinitDS := &appsv1.DaemonSet{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: common.ReinitDaemonSetName, Namespace: common.FileIntegrityNamespace}, reinitDS)
+	if err != nil && !kerr.IsNotFound(err) {
+		reqLogger.Error(err, "error getting reinit daemonSet")
+		return reconcile.Result{}, err
+	}
+	if err == nil {
+		// reinit daemonset is active, thus we are initializing
+		err := updateStatus(r.client, instance, fileintegrityv1alpha1.PhaseInitializing)
+		if err != nil {
+			reqLogger.Error(err, "error updating FileIntegrity status")
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{RequeueAfter: statusRequeue}, nil
+	}
+
+	ds := &appsv1.DaemonSet{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: common.DaemonSetName, Namespace: common.FileIntegrityNamespace}, ds)
+	if err != nil && !kerr.IsNotFound(err) {
+		reqLogger.Error(err, "error getting daemonSet")
+		return reconcile.Result{}, err
+	}
+
+	if err == nil {
+		if common.DaemonSetIsReady(ds) && !common.DaemonSetIsUpdating(ds) {
+			err := updateStatus(r.client, instance, fileintegrityv1alpha1.PhaseActive)
+			if err != nil {
+				reqLogger.Error(err, "error updating FileIntegrity status")
+				return reconcile.Result{}, err
+			}
+			return reconcile.Result{RequeueAfter: statusRequeue}, nil
+		}
+		// Not ready, set to initializing
+		err := updateStatus(r.client, instance, fileintegrityv1alpha1.PhaseInitializing)
+		if err != nil {
+			reqLogger.Error(err, "error updating FileIntegrity status")
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{RequeueAfter: statusRequeue}, nil
+	}
+
+	// both daemonSets were missing, so we're currently inactive.
+	err = updateStatus(r.client, instance, fileintegrityv1alpha1.PhasePending)
+	if err != nil {
+		reqLogger.Error(err, "error updating FileIntegrity status")
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{RequeueAfter: statusRequeue}, nil
+}
+
+func updateStatus(client client.Client, integrity *fileintegrityv1alpha1.FileIntegrity, phase fileintegrityv1alpha1.FileIntegrityStatusPhase) error {
+	if integrity.Status.Phase != phase {
+		integrityCpy := integrity.DeepCopy()
+		integrityCpy.Status.Phase = phase
+		return client.Status().Update(context.TODO(), integrityCpy)
+	}
+	return nil
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,17 +1,74 @@
 package e2e
 
 import (
+	"bytes"
 	goctx "context"
 	"testing"
 
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	fileintv1alpha1 "github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1"
 	"github.com/openshift/file-integrity-operator/pkg/common"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
 )
 
-func TestFileIntegritySingleRun(t *testing.T) {
+const (
+	testIntegrityName = "test-check"
+	testConfName      = "test-conf"
+	testConfDataKey   = "conf"
+)
+
+var testAideConfig = `@@define DBDIR /hostroot/etc/kubernetes
+# Comment added to differ from default and trigger a re-init
+@@define LOGDIR /hostroot/etc/kubernetes
+database=file:@@{DBDIR}/aide.db.gz
+database_out=file:@@{DBDIR}/aide.db.gz
+gzip_dbout=yes
+verbose=5
+report_url=file:@@{LOGDIR}/aide.log
+report_url=stdout
+ALLXTRAHASHES = sha1+rmd160+sha256+sha512+tiger
+EVERYTHING = R+ALLXTRAHASHES
+NORMAL = p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha512
+DIR = p+i+n+u+g+acl+selinux+xattrs
+PERMS = p+u+g+acl+selinux+xattrs
+LOG = p+u+g+n+S+acl+selinux+xattrs
+CONTENT = sha512+ftype
+CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
+DATAONLY =  p+n+u+g+s+acl+selinux+xattrs+sha512
+
+/hostroot/boot/        CONTENT_EX
+/hostroot/root/\..* PERMS
+/hostroot/root/   CONTENT_EX
+!/hostroot/usr/src/
+!/hostroot/usr/tmp/
+
+/hostroot/usr/    CONTENT_EX
+
+# OpenShift specific excludes
+!/hostroot/opt/
+!/hostroot/var
+!/hostroot/etc/NetworkManager/system-connections/
+!/hostroot/etc/mtab$
+!/hostroot/etc/.*~
+!/hostroot/etc/kubernetes/static-pod-resources
+!/hostroot/etc/kubernetes/aide.*
+!/hostroot/etc/docker/certs.d
+!/hostroot/etc/selinux/targeted
+
+# Catch everything else in /etc
+/hostroot/etc/    CONTENT_EX`
+
+// TestFileIntegrityConfigurationStatus tests the following:
+// - Deployment of operator and resource
+// - Successful transition from Initializing to Active
+// - Update of the AIDE configuration
+// - Successful transition to Initialization back to Active after update
+func TestFileIntegrityConfigurationStatus(t *testing.T) {
 	testctx := setupTestRequirements(t)
 	defer testctx.Cleanup()
 
@@ -27,7 +84,7 @@ func TestFileIntegritySingleRun(t *testing.T) {
 	t.Log("Creating FileIntegrity object")
 	testIntegrityCheck := &fileintv1alpha1.FileIntegrity{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-check",
+			Name:      testIntegrityName,
 			Namespace: namespace,
 		},
 		Spec: fileintv1alpha1.FileIntegritySpec{
@@ -48,7 +105,108 @@ func TestFileIntegritySingleRun(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	t.Log("ds OK")
 
-	// TODO: Check the status of the fileIntegrity object to see that we're doing alright!
+	// wait for an initialization period.
+	err = waitForScanStatus(t, f, namespace, testIntegrityName, fileintv1alpha1.PhaseInitializing)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// wait to go active
+	err = waitForScanStatus(t, f, namespace, testIntegrityName, fileintv1alpha1.PhaseActive)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// create a test AIDE config configMap
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testConfName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			testConfDataKey: testAideConfig,
+		},
+	}
+	_, err = f.KubeClient.CoreV1().ConfigMaps(namespace).Create(cm)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// update FileIntegrity config spec to point to the configMap
+	newFileIntegrity := &fileintv1alpha1.FileIntegrity{}
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: testIntegrityName, Namespace: namespace}, newFileIntegrity)
+	if err != nil {
+		t.Error(err)
+	}
+	newFileIntegrityCopy := newFileIntegrity.DeepCopy()
+	newFileIntegrityCopy.Spec = fileintv1alpha1.FileIntegritySpec{
+		Config: fileintv1alpha1.FileIntegrityConfig{
+			Name:      testConfName,
+			Namespace: namespace,
+			Key:       testConfDataKey,
+		},
+	}
+	err = f.Client.Update(goctx.TODO(), newFileIntegrityCopy)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// wait for an initialization period.
+	err = waitForScanStatus(t, f, namespace, "test-check", fileintv1alpha1.PhaseInitializing)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// wait to go active.
+	err = waitForScanStatus(t, f, namespace, "test-check", fileintv1alpha1.PhaseActive)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// confirm that the active configMap reflects the config update
+	defaultConfMap, err := f.KubeClient.CoreV1().ConfigMaps(namespace).Get(common.DefaultConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal([]byte(defaultConfMap.Data[common.DefaultConfDataKey]), []byte(testAideConfig)) {
+		t.Logf("current: %s", defaultConfMap.Data[common.DefaultConfDataKey])
+		t.Logf("intended: %s", testAideConfig)
+		t.Error("user-provided AIDE configuration did not apply")
+	}
+}
+
+// waitForScanStatus will poll until the fileintegrity that we're lookingfor reaches a certain status, or until
+// a timeout is reached.
+func waitForScanStatus(t *testing.T, f *framework.Framework, namespace, name string, targetStaus fileintv1alpha1.FileIntegrityStatusPhase) error {
+	exampleFileIntegrity := &fileintv1alpha1.FileIntegrity{}
+	var lastErr error
+	// retry and ignore errors until timeout
+	timeouterr := wait.Poll(retryInterval, timeout, func() (bool, error) {
+		lastErr = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, exampleFileIntegrity)
+		if lastErr != nil {
+			if apierrors.IsNotFound(lastErr) {
+				t.Logf("Waiting for availability of %s compliancescan\n", name)
+				return false, nil
+			}
+			t.Logf("Retrying. Got error: %v\n", lastErr)
+			return false, nil
+		}
+
+		if exampleFileIntegrity.Status.Phase == targetStaus {
+			return true, nil
+		}
+		t.Logf("Waiting for run of %s fileintegrity (%s)\n", name, exampleFileIntegrity.Status.Phase)
+		return false, nil
+	})
+	// Error in function call
+	if lastErr != nil {
+		return lastErr
+	}
+	// Timeout
+	if timeouterr != nil {
+		return timeouterr
+	}
+	t.Logf("ComplianceScan ready (%s)\n", exampleFileIntegrity.Status.Phase)
+	return nil
 }


### PR DESCRIPTION
This adds a Phase field to FileIntegrityStatus and a controller to manage it. The phases are

* Initializing - The file integrity checking is initializing: The controller sets this when the re-initialization daemonSet exists (upon config change), or the AIDE runner daemonSet is not totally ready.
* Active - The file integrity checking is currently active: The controller sets this when the AIDE runner daemonSet has available pods on all nodes.
* Inactive - There is no active integrity checking: The controller sets this when the AIDE runner daemonSet does not exist.

The controller reconciles every 30 seconds. The reason there is a continuous reconcile loop is because there is no informer action triggered by a daemonSet status update, which is what the controller monitors for status changes. So there is an initial start with the CR creation, and then it loops.