### PR TITLE
Add GOPROXY and GOSUMDB to our go invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TAG?=latest
 # ===============
 CURPATH=$(PWD)
 TARGET_DIR=$(CURPATH)/build/_output
-GO=GO111MODULE=on go
+GO=GOPROXY="https://proxy.golang.org" GOSUMDB="sum.golang.org" GO111MODULE=on go
 GOBUILD=$(GO) build
 BUILD_GOPATH=$(TARGET_DIR):$(CURPATH)/cmd
 TARGET=$(TARGET_DIR)/bin/$(APP_NAME)


### PR DESCRIPTION
This will ensure that we use golang.org's proxy instead of relying
directly on github.