### PR TITLE
Redirect output of `oc whoami`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ namespace:
 
 .PHONY: openshift-user
 openshift-user:
-ifeq ($(shell oc whoami),kube:admin)
+ifeq ($(shell oc whoami 2>/dev/null),kube:admin)
 	$(eval OPENSHIFT_USER = kubeadmin)
 else
 	$(eval OPENSHIFT_USER = $(oc whoami))


### PR DESCRIPTION
This is meant to check to if we'll need to rename kubeadmin. However,
given that it's positioned on the ifeq call. It gets called every
time.

This doesn't actually cause an error but it can be very distracting. So
lets get rid of the standard error of this command.