### PR TITLE
Ecplicitly export needed go environment files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,11 @@ TAG?=latest
 # ===============
 CURPATH=$(PWD)
 TARGET_DIR=$(CURPATH)/build/_output
-GO=GOPROXY="https://proxy.golang.org" GOSUMDB="sum.golang.org" GO111MODULE=on go
+export GOPROXY="https://proxy.golang.org"
+export GOSUMDB="sum.golang.org"
+export GO111MODULE=on
+export GOFLAGS="-mod=readonly"
+GO=GOPROXY="https://proxy.golang.org" GOSUMDB="sum.golang.org" GO111MODULE=on GOFLAGS="-mod=readonly" go
 GOBUILD=$(GO) build
 BUILD_GOPATH=$(TARGET_DIR):$(CURPATH)/cmd
 TARGET=$(TARGET_DIR)/bin/$(APP_NAME)


### PR DESCRIPTION
We can't set them via go env -w nor by passing the command before the
go command.