### PR TITLE
add an e2e test for a missing AIDE configmap

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -27,7 +27,7 @@ var aideScript = `#!/bin/sh
     done
     exit 1`
 
-var defaultAideConfig = `@@define DBDIR /hostroot/etc/kubernetes
+var DefaultAideConfig = `@@define DBDIR /hostroot/etc/kubernetes
 @@define LOGDIR /hostroot/etc/kubernetes
 database=file:@@{DBDIR}/aide.db.gz
 database_out=file:@@{DBDIR}/aide.db.gz

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -267,7 +267,7 @@ func defaultAIDEConfigMap() *corev1.ConfigMap {
 			Namespace: common.FileIntegrityNamespace,
 		},
 		Data: map[string]string{
-			"aide.conf": defaultAideConfig,
+			"aide.conf": DefaultAideConfig,
 		},
 	}
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -42,6 +42,12 @@ func cleanUp(t *testing.T, namespace string) func() error {
 		if err := f.KubeClient.AppsV1().DaemonSets(namespace).Delete("aide-clean", &metav1.DeleteOptions{}); err != nil {
 			return err
 		}
+
+		if err := f.KubeClient.CoreV1().ConfigMaps(namespace).Delete(common.DefaultConfigMapName, &metav1.DeleteOptions{}); err != nil {
+			if !kerr.IsNotFound(err) {
+				return err
+			}
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
This test just ensures there's no re-init when you specify a nonexistant AIDE configmap, plus some refactoring.