### PR TITLE
Up timeout to 15 min

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -22,7 +22,7 @@ import (
 const (
 	pollInterval         = time.Second * 2
 	retryInterval        = time.Second * 5
-	timeout              = time.Minute * 10
+	timeout              = time.Minute * 15
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Minute * 5
 )


### PR DESCRIPTION
The initialization stage is taking too long for some reason. Lets pu the
timeout to 15 min to reduce the errors in CI while we fix this.