### PR TITLE
deploy: change operator image to internal repo

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: file-integrity-operator
           # Replace this with the built image name
-          image: docker.io/mrogers950/file-integrity-operator
+          image: image-registry.openshift-image-registry.svc:5000/openshift-file-integrity/file-integrity-operator:latest
           command:
           - file-integrity-operator
           imagePullPolicy: Always


### PR DESCRIPTION
This makes a in-cluster deployment easier with `make image-to-cluster`