### PR TITLE
Tie AIDE config to FileIntegrity Object

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -23,11 +23,9 @@ const (
 	AideReinitScriptConfigMapName   = "aide-reinit"
 	AideScriptConfigMapName         = "aide-script"
 	AideScriptPath                  = "/scripts/aide.sh"
-	DaemonSetName                   = "aide-ds"
+	DaemonSetPrefix                 = "aide-ds"
 	DefaultConfDataKey              = "aide.conf"
-	DefaultConfigMapName            = "aide-conf"
 	FileIntegrityNamespace          = "openshift-file-integrity"
-	LogCollectorDaemonSetName       = "logcollector"
 	OperatorServiceAccountName      = "file-integrity-operator"
-	ReinitDaemonSetName             = "aide-reinit-ds"
+	ReinitDaemonSetPrefix           = "aide-reinit-ds"
 )

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -72,3 +72,15 @@ func IgnoreAlreadyExists(err error) error {
 	}
 	return err
 }
+
+// GetDaemonSetName gets the name of the owner (usually a FileIntegrity CR) and
+// returns an appropriate name for the DaemonSet that's owned by it.
+func GetDaemonSetName(name string) string {
+	return DaemonSetPrefix + "-" + name
+}
+
+// GetReinitDaemonSetName gets the name of the owner (usually a FileIntegrity CR) and
+// returns an appropriate name for the DaemonSet that's owned by it.
+func GetReinitDaemonSetName(name string) string {
+	return ReinitDaemonSetPrefix + "-" + name
+}

--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -119,7 +119,8 @@ func (r *ReconcileConfigMap) reconcileAideConf(instance *corev1.ConfigMap, logge
 	// daemonSets that they need to back up and re-initialize the AIDE database. So once we've confirmed that the
 	// re-init daemonSets have started running we can delete them and continue with the rollout of the AIDE pods.
 	reinitDS := &appsv1.DaemonSet{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: common.ReinitDaemonSetName, Namespace: common.FileIntegrityNamespace}, reinitDS)
+	reinitDSName := common.GetReinitDaemonSetName(instance.Name)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: reinitDSName, Namespace: common.FileIntegrityNamespace}, reinitDS)
 	if err != nil {
 		// includes notFound, we will requeue here at least once.
 		logger.Error(err, "error getting reinit daemonSet")
@@ -139,7 +140,8 @@ func (r *ReconcileConfigMap) reconcileAideConf(instance *corev1.ConfigMap, logge
 	}
 
 	ds := &appsv1.DaemonSet{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: common.DaemonSetName, Namespace: common.FileIntegrityNamespace}, ds)
+	dsName := common.GetDaemonSetName(instance.Name)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: dsName, Namespace: common.FileIntegrityNamespace}, ds)
 	if err != nil {
 		logger.Error(err, "error getting daemonSet")
 		return reconcile.Result{}, err

--- a/pkg/controller/status/status_controller.go
+++ b/pkg/controller/status/status_controller.go
@@ -87,7 +87,8 @@ func (r *ReconcileFileIntegrityStatus) Reconcile(request reconcile.Request) (rec
 
 	// first check is for the reinit daemonset, when this exists at all we are in an initialization phase.
 	reinitDS := &appsv1.DaemonSet{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: common.ReinitDaemonSetName, Namespace: common.FileIntegrityNamespace}, reinitDS)
+	reinitDSName := common.GetReinitDaemonSetName(instance.Name)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: reinitDSName, Namespace: common.FileIntegrityNamespace}, reinitDS)
 	if err != nil && !kerr.IsNotFound(err) {
 		reqLogger.Error(err, "error getting reinit daemonSet")
 		return reconcile.Result{}, err
@@ -103,7 +104,8 @@ func (r *ReconcileFileIntegrityStatus) Reconcile(request reconcile.Request) (rec
 	}
 
 	ds := &appsv1.DaemonSet{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: common.DaemonSetName, Namespace: common.FileIntegrityNamespace}, ds)
+	dsName := common.GetDaemonSetName(instance.Name)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: dsName, Namespace: common.FileIntegrityNamespace}, ds)
 	if err != nil && !kerr.IsNotFound(err) {
 		reqLogger.Error(err, "error getting daemonSet")
 		return reconcile.Result{}, err

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -13,7 +14,6 @@ import (
 	fileintv1alpha1 "github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1"
 	"github.com/openshift/file-integrity-operator/pkg/common"
 	"github.com/openshift/file-integrity-operator/pkg/controller/fileintegrity"
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
 )
 
 const (
@@ -95,9 +95,10 @@ func setupTest(t *testing.T) (*framework.Framework, *framework.TestCtx, string) 
 		t.Errorf("could not create fileintegrity object: %v", err)
 	}
 
-	err = waitForDaemonSet(daemonSetIsReady(f.KubeClient, common.DaemonSetName, namespace))
+	dsName := common.GetDaemonSetName(testIntegrityCheck.Name)
+	err = waitForDaemonSet(daemonSetIsReady(f.KubeClient, dsName, namespace))
 	if err != nil {
-		t.Errorf("Timed out waiting for DaemonSet %s", common.DaemonSetName)
+		t.Errorf("Timed out waiting for DaemonSet %s", dsName)
 	}
 
 	// wait to go active
@@ -228,7 +229,7 @@ func TestFileIntegrityConfigurationStatus(t *testing.T) {
 		t.Errorf("Timeout waiting for scan status")
 	}
 
-	if err := pollUntilConfigMapDataMatches(t, f, namespace, common.DefaultConfigMapName, common.DefaultConfDataKey,
+	if err := pollUntilConfigMapDataMatches(t, f, namespace, testIntegrityName, common.DefaultConfDataKey,
 		testAideConfig, time.Second*5, time.Minute*5); err != nil {
 		t.Errorf("Timeout waiting for configMap data to match")
 	}
@@ -262,7 +263,7 @@ func TestFileIntegrityConfigurationIgnoreMissing(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := pollUntilConfigMapDataMatches(t, f, namespace, common.DefaultConfigMapName, common.DefaultConfDataKey,
+	if err := pollUntilConfigMapDataMatches(t, f, namespace, testIntegrityName, common.DefaultConfDataKey,
 		fileintegrity.DefaultAideConfig, time.Second*5, time.Minute*5); err != nil {
 		t.Errorf("Timeout waiting for configMap data to match")
 	}


### PR DESCRIPTION
This ties the AIDE ConfigMap to the FileIntegrity object by giving them
the same name. Effectively, this ends up making the configurations
unique per file-integrity object, as opposed to relying on a single
ConfigMap.

This is the first step on enabling us to use multiple FileIntegrities
per deployment (which would ideally serve different node sets).

Given that the name of the config file matches the name of the
FileIntegrity, we can infer the DaemonSet name from it. Which are also
now unique per CR instance.