### PR TITLE
Allow setting workload images through environment variables

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -32,6 +32,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "file-integrity-operator"
+            - name: AIDE_IMAGE
+              value: "quay.io/mrogers950/aide:latest"
+            - name: LOGCOLLECTOR_IMAGE
+              value: "quay.io/mrogers950/file-integrity-logcollector:latest"
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -349,7 +349,7 @@ func reinitAideDaemonset(reinitDaemonSetName string) *appsv1.DaemonSet {
 								RunAsUser:  &runAs,
 							},
 							Name:    "aide",
-							Image:   "quay.io/mrogers950/aide:latest",
+							Image:   GetComponentImage(AIDE),
 							Command: []string{common.AideScriptPath},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -437,7 +437,7 @@ func aideDaemonset(dsName string, fi *fileintegrityv1alpha1.FileIntegrity) *apps
 								RunAsUser:  &runAs,
 							},
 							Name:    "aide-ds-init",
-							Image:   "quay.io/mrogers950/aide:latest",
+							Image:   GetComponentImage(AIDE),
 							Command: []string{common.AideScriptPath},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -462,7 +462,7 @@ func aideDaemonset(dsName string, fi *fileintegrityv1alpha1.FileIntegrity) *apps
 								RunAsUser:  &runAs,
 							},
 							Name:    "aide",
-							Image:   "quay.io/mrogers950/aide:latest",
+							Image:   GetComponentImage(AIDE),
 							Command: []string{common.AideScriptPath},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -484,7 +484,7 @@ func aideDaemonset(dsName string, fi *fileintegrityv1alpha1.FileIntegrity) *apps
 								Privileged: &priv,
 							},
 							Name:  "logcollector",
-							Image: "quay.io/mrogers950/file-integrity-logcollector:latest",
+							Image: GetComponentImage(LOGCOLLECTOR),
 							Args: []string{
 								"--file=" + aideLogPath,
 								"--config-map-prefix=" + dsName,

--- a/pkg/controller/fileintegrity/utils.go
+++ b/pkg/controller/fileintegrity/utils.go
@@ -1,0 +1,32 @@
+package fileintegrity
+
+import (
+	"os"
+)
+
+type FileIntegrityComponent uint
+
+const (
+	AIDE = iota
+	LOGCOLLECTOR
+)
+
+var componentDefaults = []struct {
+	defaultImage string
+	envVar       string
+}{
+	{"quay.io/mrogers950/aide:latest", "AIDE_IMAGE"},
+	{"quay.io/mrogers950/file-integrity-logcollector:latest", "LOGCOLLECTOR_IMAGE"},
+}
+
+// GetComponentImage returns a full image pull spec for a given component
+// based on the component type
+func GetComponentImage(component FileIntegrityComponent) string {
+	comp := componentDefaults[component]
+
+	imageTag := os.Getenv(comp.envVar)
+	if imageTag == "" {
+		imageTag = comp.defaultImage
+	}
+	return imageTag
+}


### PR DESCRIPTION
This allows us to set the workload images through environment variables,
like we do for the compliance-operator.