### PR TITLE
Exclude /etc/kubernetes/manifests from default AIDE policy

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -65,6 +65,7 @@ DATAONLY =  p+n+u+g+s+acl+selinux+xattrs+sha512
 !/hostroot/etc/.*~
 !/hostroot/etc/kubernetes/static-pod-resources
 !/hostroot/etc/kubernetes/aide.*
+!/hostroot/etc/kubernetes/manifests
 !/hostroot/etc/docker/certs.d
 !/hostroot/etc/selinux/targeted
 


### PR DESCRIPTION
Files under /etc/kubernetes/manifests/ can be changed by the cluster-kube-apiserver-operator during normal use, so add this directory to the default policy.
@openshift/infrastructure-security-compliance 