### PR TITLE
e2e: Change modify file path

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -31,6 +31,7 @@ var aideScript = `#!/bin/sh
     done
     exit 1`
 
+// NOTE: Needs to be in sync with `testAideConfig` in test/e2e/helpers.go, except for the heading comment.
 var DefaultAideConfig = `@@define DBDIR /hostroot/etc/kubernetes
 @@define LOGDIR /hostroot/etc/kubernetes
 database=file:@@{DBDIR}/aide.db.gz

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -72,6 +72,7 @@ DATAONLY =  p+n+u+g+s+acl+selinux+xattrs+sha512
 !/hostroot/etc/.*~
 !/hostroot/etc/kubernetes/static-pod-resources
 !/hostroot/etc/kubernetes/aide.*
+!/hostroot/etc/kubernetes/manifests
 !/hostroot/etc/docker/certs.d
 !/hostroot/etc/selinux/targeted
 
@@ -216,7 +217,7 @@ func cleanAideDaemonset(namespace string) *appsv1.DaemonSet {
 
 func modifyFileDaemonset(namespace string) *appsv1.DaemonSet {
 	return privCommandDaemonset(namespace, "aide-modify-file",
-		"echo foobar >> /hostroot/etc/kubernetes/cloud.conf || true",
+		"echo '#foobar' >> /hostroot/etc/resolv.conf || true",
 	)
 }
 
@@ -517,7 +518,7 @@ func containsUncompressedScanFailLog(data map[string]string) bool {
 	if !ok {
 		return false
 	}
-	return strings.Contains(content, "/hostroot/etc/kubernetes/cloud.conf")
+	return strings.Contains(content, "/hostroot/etc/resolv.conf")
 }
 
 func editFileOnNodes(f *framework.Framework, namespace string) error {


### PR DESCRIPTION
Using /etc/kubernetes/cloud.conf for this test was causing problems, so modify
it to an innocuous change (a comment) to a file we know will always exist on
the node (resolv.conf).

Additionally, update the test config so the config change test remains
accurate.