### PR TITLE
make: Drop deprecated operator-sdk generate openapi, use generate crds instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,9 +159,9 @@ gosec:
 	@$(GO) run github.com/securego/gosec/cmd/gosec -severity medium -confidence medium -quiet ./...
 
 .PHONY: generate
-generate: operator-sdk ## Run operator-sdk's code generation (k8s and openapi)
+generate: operator-sdk ## Run operator-sdk's code generation (k8s and crds)
 	$(GOPATH)/bin/operator-sdk generate k8s
-	$(GOPATH)/bin/operator-sdk generate openapi
+	$(GOPATH)/bin/operator-sdk generate crds
 
 .PHONY: test-unit
 test-unit: fmt ## Run the unit tests


### PR DESCRIPTION
Currently we're getting a deprecation warning:
[Deprecation notice] The 'operator-sdk generate openapi' command is deprecated!

 - To generate CRDs, use 'operator-sdk generate crds'.
 - To generate Go OpenAPI code, use 'openapi-gen'. For example:

      # Build the latest openapi-gen from source
      which ./bin/openapi-gen > /dev/null || go build -o ./bin/openapi-gen k8s.io/kube-openapi/cmd/openapi-gen

      # Run openapi-gen for each of your API group/version packages
      ./bin/openapi-gen --logtostderr=true -o "" -i ./pkg/apis/<group>/<version> -O zz_generated.openapi -p ./pkg/apis/<group>/<version> -h ./hack/boilerplate.go.txt -r "-"