### PR TITLE
reinit e2e: Test that nodes are in good state after re-init

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -26,6 +26,9 @@ func TestFileIntegrityLogAndReinitDatabase(t *testing.T) {
 		t.Errorf("Timeout waiting for scan status")
 	}
 
+	t.Log("Asserting that the FileIntegrity check is in a SUCCESS state after deploying it")
+	assertNodesConditionIsSuccess(t, f, namespace, testIntegrityName, 2*time.Second, 5*time.Minute)
+
 	// modify a file on a node
 	err = editFileOnNodes(f, namespace)
 	if err != nil {
@@ -65,6 +68,9 @@ func TestFileIntegrityLogAndReinitDatabase(t *testing.T) {
 	if err != nil {
 		t.Errorf("Timeout waiting for scan status")
 	}
+
+	t.Log("Asserting that the FileIntegrity check is in a SUCCESS state after re-initializing the database")
+	assertNodesConditionIsSuccess(t, f, namespace, testIntegrityName, 2*time.Second, 5*time.Minute)
 }
 
 // TestFileIntegrityConfigurationStatus tests the following:

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	goctx "context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -472,6 +473,57 @@ func waitForFailedStatusForNode(t *testing.T, f *framework.Framework, namespace,
 	}
 
 	return foundStatus, nil
+}
+
+func assertNodesConditionIsSuccess(t *testing.T, f *framework.Framework, namespace, name string, interval, timeout time.Duration) {
+	fi := &fileintv1alpha1.FileIntegrity{}
+	var lastErr error
+	type nodeStatus struct {
+		LastProbeTime metav1.Time
+		Condition     fileintv1alpha1.FileIntegrityNodeCondition
+	}
+	// Node names are the key
+	latestStatuses := map[string]nodeStatus{}
+	wait.Poll(interval, timeout, func() (bool, error) {
+		getErr := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, fi)
+		if getErr != nil {
+			t.Logf("Retrying. Got error: %v\n", getErr)
+			lastErr = getErr
+			return false, nil
+		}
+
+		// gather statuses
+		for _, status := range fi.Status.Statuses {
+			t.Logf("Iterating through statuses: Found node status: %s - %s", status.NodeName, status.Condition)
+			recordedStatus, ok := latestStatuses[status.NodeName]
+			if !ok {
+				latestStatuses[status.NodeName] = nodeStatus{
+					LastProbeTime: status.LastProbeTime,
+					Condition:     status.Condition,
+				}
+			} else if recordedStatus.LastProbeTime.Before(&status.LastProbeTime) {
+				latestStatuses[status.NodeName] = nodeStatus{
+					LastProbeTime: status.LastProbeTime,
+					Condition:     status.Condition,
+				}
+			}
+		}
+
+		// iterate gathered statuses
+		for nodeName, status := range latestStatuses {
+			if status.Condition != fileintv1alpha1.NodeConditionSucceeded {
+				lastErr = fmt.Errorf("status.nodeStatus for node %s NOT SUCCESS: But instead %s", nodeName, status.Condition)
+				return false, nil
+
+			}
+		}
+		// reset error since we're good
+		lastErr = nil
+		return true, nil
+	})
+	if lastErr != nil {
+		t.Errorf("ERROR: nodes weren't in good state: %s", lastErr)
+	}
 }
 
 // waitForScanStatus will poll until the fileintegrity that we're looking for reaches a certain status, or until


### PR DESCRIPTION
The re-init e2e test was only verifying that the FileIntegrity is
Active. But this is not enough. We also need to verify that the nodes
are in a good state (Succeeded) after the database has been
re-initialized.