### PR TITLE
FI controller: Make the interval and the debug flag configurable

### DIFF
--- a/cmd/manager/logcollector.go
+++ b/cmd/manager/logcollector.go
@@ -49,7 +49,6 @@ const (
 	maxRetries    = 15
 	// These need to be lessened for normal use.
 	defaultTimeout       = 600
-	defaultInterval      = 1800
 	defaultIndicatorFile = "/hostroot/etc/kubernetes/aide.latest-result.log"
 	uncompressedMaxSize  = 1048570 // 1MB for etcd limit
 )
@@ -109,7 +108,7 @@ func defineFlags(cmd *cobra.Command) {
 	cmd.Flags().String("config-map-prefix", "", "Prefix for the configMap name, typically the podname.")
 	cmd.Flags().String("namespace", "Running pod namespace.", ".")
 	cmd.Flags().Int64("timeout", defaultTimeout, "How long to poll for the log and indicator files in seconds.")
-	cmd.Flags().Int64("interval", defaultInterval, "How often to recheck for .")
+	cmd.Flags().Int64("interval", common.DefaultGracePeriod, "How often to recheck for AIDE results.")
 	cmd.Flags().Bool("compress", false, "Use gzip+base64 to compress the log file contents.")
 	cmd.Flags().Bool("debug", false, "Print debug messages")
 }

--- a/deploy/crds/file-integrity.openshift.io_fileintegrities_crd.yaml
+++ b/deploy/crds/file-integrity.openshift.io_fileintegrities_crd.yaml
@@ -45,6 +45,8 @@ spec:
                 namespace:
                   type: string
               type: object
+            debug:
+              type: boolean
             nodeSelector:
               additionalProperties:
                 type: string

--- a/deploy/crds/file-integrity.openshift.io_fileintegrities_crd.yaml
+++ b/deploy/crds/file-integrity.openshift.io_fileintegrities_crd.yaml
@@ -35,6 +35,9 @@ spec:
               description: FileIntegrityConfig defines the name, namespace, and data
                 key for an AIDE config to use for integrity checking.
               properties:
+                gracePeriod:
+                  description: Time between individual aide scans
+                  type: integer
                 key:
                   type: string
                 name:

--- a/deploy/crds/file-integrity.openshift.io_v1alpha1_fileintegrity_cr.yaml
+++ b/deploy/crds/file-integrity.openshift.io_v1alpha1_fileintegrity_cr.yaml
@@ -4,4 +4,7 @@ metadata:
   name: example-fileintegrity
   namespace: openshift-file-integrity
 spec:
+  # Change to debug: true to enable more verbose logging from the logcollector
+  # container in the aide pods
+  debug: false
   config: {}

--- a/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
+++ b/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
@@ -28,6 +28,7 @@ const (
 type FileIntegritySpec struct {
 	NodeSelector map[string]string   `json:"nodeSelector,omitempty"`
 	Config       FileIntegrityConfig `json:"config"`
+	Debug        bool                `json:"debug,omitempty"`
 }
 
 // FileIntegrityConfig defines the name, namespace, and data key for an AIDE config to use for integrity checking.

--- a/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
+++ b/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
@@ -36,6 +36,8 @@ type FileIntegrityConfig struct {
 	Name      string `json:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 	Key       string `json:"key,omitempty"`
+	// Time between individual aide scans
+	GracePeriod int `json:"gracePeriod,omitempty"`
 }
 
 // FileIntegrityStatus defines the observed state of FileIntegrity

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -3,6 +3,8 @@ package common
 const (
 	// AideConfigLabelKey tells us if a specific ConfigMap is an AIDE config
 	AideConfigLabelKey = "file-integrity.openshift.io/aide-conf"
+	// AideScriptLabelKey tells us if a specific ConfigMap is an AIDE script
+	AideScriptLabelKey = "file-integrity.openshift.io/aide-script"
 	// AideConfigUpdatedAnnotationKey tells us if an aide config needs updating
 	AideConfigUpdatedAnnotationKey = "file-integrity.openshift.io/updated"
 	// AideDatabaseReinitAnnotationKey tells us if an aide config needs updating
@@ -33,9 +35,11 @@ const (
 	AideScriptConfigMapName            = "aide-script"
 	PauseConfigMapName                 = "aide-pause"
 	PausePath                          = "/scripts/pause.sh"
+	AideScriptConfigMapPrefix          = "aide-script"
 	AideScriptPath                     = "/scripts/aide.sh"
 	DaemonSetPrefix                    = "aide-ds"
 	DefaultConfDataKey                 = "aide.conf"
+	AideScriptKey                      = "aide.sh"
 	OperatorServiceAccountName         = "file-integrity-operator"
 	ReinitDaemonSetPrefix              = "aide-reinit-ds"
 	// IntegrityCheckHoldoffFilePath specified the path to the file that tells
@@ -43,4 +47,6 @@ const (
 	IntegrityCheckHoldoffFilePath = "/hostroot/etc/kubernetes/holdoff"
 	// IntegrityHoldoffAnnotationKey indicates that there was an error in the logcollector
 	IntegrityHoldoffAnnotationKey = "file-integrity.openshift.io/holdoff"
+	// The minimal and at the same time default gracePeriod
+	DefaultGracePeriod = 10
 )

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -2,11 +2,10 @@ package common
 
 import (
 	"fmt"
-	"os"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
+	"os"
 )
 
 type FileIntegrityComponent uint
@@ -40,6 +39,13 @@ func GetComponentImage(component FileIntegrityComponent) string {
 // label that indicates that this is an AIDE config.
 func IsAideConfig(labels map[string]string) bool {
 	_, ok := labels[AideConfigLabelKey]
+	return ok
+}
+
+// IsAideScript returns whether the given map contains a
+// label that indicates that this is an AIDE script
+func IsAideScript(labels map[string]string) bool {
+	_, ok := labels[AideScriptLabelKey]
 	return ok
 }
 
@@ -99,6 +105,12 @@ func IgnoreAlreadyExists(err error) error {
 		return nil
 	}
 	return err
+}
+
+// GetScriptName returns the name of a configMap for a FI object with a
+// given name
+func GetScriptName(fiName string) string {
+	return AideScriptConfigMapPrefix + "-" + fiName
 }
 
 // GetDaemonSetName gets the name of the owner (usually a FileIntegrity CR) and

--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -31,8 +31,7 @@ var aidePauseContainerScript = `#!/bin/sh
 // /hostroot/etc/kubernetes/aide.latest-result.log file.
 // If the file /hostroot/etc/kubernetes/holdoff is found, the check
 // is skipped
-// TODO: Make time configurable
-var aideScript = `#!/bin/sh
+var aideScriptTemplate = `#!/bin/sh
     while true; do
       if [ -f /hostroot/etc/kubernetes/holdoff ]; then
         continue
@@ -41,8 +40,8 @@ var aideScript = `#!/bin/sh
       aide -c /tmp/aide.conf
       result=$?
       echo "$result" > /hostroot/etc/kubernetes/aide.latest-result.log
-      echo "AIDE check returned $result.. sleeping"
-      sleep 10s
+      echo "AIDE check returned $result.. sleeping for %[1]d seconds"
+      sleep %[1]d
     done
     exit 1`
 

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -654,8 +654,7 @@ func aideDaemonset(dsName string, fi *fileintegrityv1alpha1.FileIntegrity) *apps
 								"--owner=" + fi.Name,
 								"--namespace=" + fi.Namespace,
 								"--interval=" + strconv.Itoa(gracePeriod),
-								// TODO: remove this for production
-								"--debug=true",
+								"--debug=" + strconv.FormatBool(fi.Spec.Debug),
 							},
 							Env: []corev1.EnvVar{
 								{

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -653,7 +653,6 @@ func aideDaemonset(dsName string, fi *fileintegrityv1alpha1.FileIntegrity) *apps
 								"--config-map-prefix=" + dsName,
 								"--owner=" + fi.Name,
 								"--namespace=" + fi.Namespace,
-								"--timeout=2",
 								"--interval=" + strconv.Itoa(gracePeriod),
 								// TODO: remove this for production
 								"--debug=true",


### PR DESCRIPTION
FI ctrl: Make debugging of the aggregator configurable
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

The aggregator pod can optionally produce some debug information, but the
debug flag was hardcoded to false. This patch extends the FileIntegritySpec
struture with a new field, debug, that defaults to false. The admin can
enable debugging of the logcollector by setting the debug flag to true.

FI ctrl: Don't set the timeout explicitly
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Setting the timeout explicitly or even making the timeout configurable is 
not really needed, because if the timeout occurs, the loop that waits for
the files the aggregator is watching simply takes another iteration.

FI ctrl: Make the interval configurable
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Extends the FileIntegrityConfig structure with a new member Interval. If 
not set, its value defaults to 10 seconds, otherwise the configured value
is used for both the aide integrity scanner and the interval in which the
logcollector checks for aide results.

Jira: CMP-436