### PR TITLE
FI: Don't use a third-party container image

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -31,6 +31,8 @@ const (
 	AideInitScriptConfigMapName        = "aide-init"
 	AideReinitScriptConfigMapName      = "aide-reinit"
 	AideScriptConfigMapName            = "aide-script"
+	PauseConfigMapName                 = "aide-pause"
+	PausePath                          = "/scripts/pause.sh"
 	AideScriptPath                     = "/scripts/aide.sh"
 	DaemonSetPrefix                    = "aide-ds"
 	DefaultConfDataKey                 = "aide.conf"

--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -21,6 +21,12 @@ var aideReinitContainerScript = `#!/bin/sh
     touch /hostroot/etc/kubernetes/aide.reinit
 `
 
+var aidePauseContainerScript = `#!/bin/sh
+	sleep infinity & PID=$!
+	trap "kill $PID" INT TERM
+	wait $PID || true
+`
+
 // An AIDE run is executed every 10s and the output is set in the
 // /hostroot/etc/kubernetes/aide.latest-result.log file.
 // If the file /hostroot/etc/kubernetes/holdoff is found, the check


### PR DESCRIPTION
Using container images from a public registry migth break disconnected
installs.