### PR TITLE
make: Fix make run after upgrade to operator-sdk 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ run: operator-sdk ## Run the file-integrity-operator locally
 	WATCH_NAMESPACE=$(NAMESPACE) \
 	KUBERNETES_CONFIG=$(KUBECONFIG) \
 	OPERATOR_NAME=$(APP_NAME) \
-	$(GOPATH)/bin/operator-sdk run --local --namespace $(NAMESPACE)
+	$(GOPATH)/bin/operator-sdk run --local --watch-namespace $(NAMESPACE) --operator-flags operator
 
 .PHONY: clean
 clean: clean-modcache clean-cache clean-output ## Clean the golang environment


### PR DESCRIPTION
Otherwise we'd just receive:
INFO[0000] --namespace is deprecated; use --watch-namespace instead.
and the operator then quits

In addition to the --watch-namespace change, there is also another
change that adds "operator-flags operator" which is needed since we
collapsed all the functionality into a single binary.