### PR TITLE
daemon: Change result handling to use channels instead of mutexes

### DIFF
--- a/cmd/manager/logcollector.go
+++ b/cmd/manager/logcollector.go
@@ -309,7 +309,7 @@ func updateReadOffset(rt *daemonRuntime, file *os.File, contents []byte) error {
 // into permanent ones. It reads the last result reported from aide.
 func logCollectorMainLoop(rt *daemonRuntime, conf *daemonConfig, ch chan bool) {
 	for {
-		lastResult := rt.Result()
+		lastResult := <-rt.result
 		// We haven't received a result yet.
 		if lastResult == -1 {
 			DBG("No scan result available")
@@ -356,6 +356,5 @@ func logCollectorMainLoop(rt *daemonRuntime, conf *daemonConfig, ch chan bool) {
 		}
 
 		uploadLog(contents, compressed, conf, rt)
-		time.Sleep(time.Duration(conf.Interval) * time.Second)
 	}
 }


### PR DESCRIPTION
This reduces the code a little bit and makes the log collector and aide
loop have their synchronization dependent on whether there's a result or
not.

This way, the only "sleep" is done in the aide loop, and the log
collector will only collect if there is indeed a result ready.