### PR TITLE
Use buffered channel for results in daemon

### DIFF
--- a/cmd/manager/daemon.go
+++ b/cmd/manager/daemon.go
@@ -166,7 +166,7 @@ func daemonMainLoop(cmd *cobra.Command, args []string) {
 		dynclient: dynclient,
 	}
 
-	rt.result = make(chan int)
+	rt.result = make(chan int, 50)
 
 	// Set initial states so the loops do not race in the beginning.
 	rt.result <- -1


### PR DESCRIPTION
The current implementation (as well as the previous one based on
mutexes) makes the daemon run in still a sort of serial manner.

The channel added a more go-friendly behavior to the go routines, by
handling shared structures through message passing. However, it's still
fairly serial. Both go-routines (the aide check and the log collector)
will be blocked until both are ready for receiving messages.

Introducing a buffered channel enables us to deal with this in a more
elegant way.

The sender (the aide check go routine) will be able to send and continue
to loop as long as there's cycles in the channel.

The receiver will be blocked until there are messages to receive.

This way, the main "blocking point" is the aide checker, which is the
one that sleeps with a grace period, and that will be "producing"
results.

The log collector will continue as long as it gets results. If the
daemon is being throttled and takes too long, the aide checker can
continue doing checks.

The current value of the buffer was chosen arbitrarily. But it's a
number that's big enough that if we have a temporary network
connectivity loss, hopefully the log collector will be able to recover.