### PR TITLE
Rename image env variables for downstream

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -33,9 +33,9 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "file-integrity-operator"
-            - name: AIDE_IMAGE
+            - name: RELATED_IMAGE_AIDE
               value: "quay.io/file-integrity-operator/aide:latest"
-            - name: OPERATOR_IMAGE
+            - name: RELATED_IMAGE_OPERATOR
               value: "quay.io/file-integrity-operator/file-integrity-operator:latest"
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -26,8 +26,8 @@ var componentDefaults = []struct {
 	defaultImage string
 	envVar       string
 }{
-	{"quay.io/file-integrity-operator/aide:latest", "AIDE_IMAGE"},
-	{"quay.io/file-integrity-operator/file-integrity-operator:latest", "OPERATOR_IMAGE"},
+	{"quay.io/file-integrity-operator/aide:latest", "RELATED_IMAGE_AIDE"},
+	{"quay.io/file-integrity-operator/file-integrity-operator:latest", "RELATED_IMAGE_OPERATOR"},
 }
 
 // GetComponentImage returns a full image pull spec for a given component


### PR DESCRIPTION
The RHBS digest pinning feature relies on RELATED_IMAGE_* variables to do image reference substitution.
@jhrozek 