### PR TITLE
Use own role and service account for daemon

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -70,6 +70,34 @@ rules:
   - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: file-integrity-daemon
+  namespace: openshift-file-integrity
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - "fileintegrity.openshift.io"
+  resources:
+  - fileintegrities
+  verbs:
+  - get
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: file-integrity-operator

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -11,6 +11,19 @@ roleRef:
   name: file-integrity-operator
   apiGroup: rbac.authorization.k8s.io
 ---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: file-integrity-daemon
+  namespace: openshift-file-integrity
+subjects:
+- kind: ServiceAccount
+  name: file-integrity-daemon
+roleRef:
+  kind: Role
+  name: file-integrity-daemon
+  apiGroup: rbac.authorization.k8s.io
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -3,4 +3,9 @@ kind: ServiceAccount
 metadata:
   name: file-integrity-operator
   namespace: openshift-file-integrity
-
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: file-integrity-daemon
+  namespace: openshift-file-integrity

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -39,6 +39,7 @@ const (
 	DefaultConfDataKey                 = "aide.conf"
 	AideScriptKey                      = "aide.sh"
 	OperatorServiceAccountName         = "file-integrity-operator"
+	DaemonServiceAccountName           = "file-integrity-daemon"
 	ReinitDaemonSetPrefix              = "aide-reinit-ds"
 	// IntegrityCheckHoldoffFilePath specified the path to the file that tells
 	// the AIDE check to hold off


### PR DESCRIPTION
This creates a service account and a role specific for the daemon,
ensuring that it only runs with the minimal set of permissions it needs.