### PR TITLE
Make default grace period to be 15 min

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In the `spec`:
 * **nodeSelector**: Selector for nodes to schedule the scan instances on.
 * **tolerations**: Specify tolerations to schedule on nodes with custom taints. When not specified, a default toleration allowing running on master nodes is applied.
 * **config**: Point to a configMap containing an AIDE configuration to use instead of the CoreOS optimized default. See "Applying an AIDE config" below.
-* **config.gracePeriod**: The number of seconds to pause in between AIDE integrity checks. Frequent AIDE checks on a node may be resource intensive, so it can be useful to specify a longer interval. Defaults to 10.
+* **config.gracePeriod**: The number of seconds to pause in between AIDE integrity checks. Frequent AIDE checks on a node may be resource intensive, so it can be useful to specify a longer interval. Defaults to 3600 (one hour).
 
 In the `status`:
 * **phase**: The running status of the `FileIntegrity` instance. Can be `Initializing`, `Pending`, or `Active`. `Initializing` is displayed if the FileIntegrity is currently initializing or re-initializing the AIDE database, `Pending` if the FileIntegrity deployment is still being created, and `Active` if the scans are active and ongoing. For node scan results, see the `FileIntegrityNodeStatus` objects explained below.

--- a/deploy/crds/fileintegrity.openshift.io_fileintegrities_crd.yaml
+++ b/deploy/crds/fileintegrity.openshift.io_fileintegrities_crd.yaml
@@ -36,6 +36,7 @@ spec:
                   data key for an AIDE config to use for integrity checking.
                 properties:
                   gracePeriod:
+                    default: 900
                     description: Time between individual aide scans
                     type: integer
                   key:

--- a/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
+++ b/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
@@ -42,6 +42,7 @@ type FileIntegrityConfig struct {
 	Namespace string `json:"namespace,omitempty"`
 	Key       string `json:"key,omitempty"`
 	// Time between individual aide scans
+	// +kubebuilder:default=900
 	GracePeriod int `json:"gracePeriod,omitempty"`
 }
 

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -46,6 +46,6 @@ const (
 	IntegrityCheckHoldoffFilePath = "/hostroot/etc/kubernetes/holdoff"
 	// IntegrityHoldoffAnnotationKey indicates that there was an error in the logcollector
 	IntegrityHoldoffAnnotationKey = "file-integrity.openshift.io/holdoff"
-	// The minimal and at the same time default gracePeriod
-	DefaultGracePeriod = 10
+	// The default gracePeriod
+	DefaultGracePeriod = 900
 )

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -141,7 +141,9 @@ func TestFileIntegrityConfigurationRevert(t *testing.T) {
 	}
 
 	fileIntegrityCopy := fileIntegrity.DeepCopy()
-	fileIntegrityCopy.Spec.Config = fileintv1alpha1.FileIntegrityConfig{}
+	fileIntegrityCopy.Spec.Config = fileintv1alpha1.FileIntegrityConfig{
+		GracePeriod: defaultTestGracePeriod,
+	}
 
 	err = f.Client.Update(context.TODO(), fileIntegrityCopy)
 	if err != nil {
@@ -300,7 +302,7 @@ func TestFileIntegrityChangeGracePeriod(t *testing.T) {
 	}
 
 	// get daemonSet, make sure there's the default sleep
-	defaultSleep := fmt.Sprintf("--interval=%d", common.DefaultGracePeriod)
+	defaultSleep := fmt.Sprintf("--interval=%d", defaultTestGracePeriod)
 	err = assertDSPodHasArg(t, f, testIntegrityName, namespace, defaultSleep, time.Second*5, time.Minute*5)
 	if err != nil {
 		t.Errorf("pod spec didn't contain the expected sleep: %v\n", err)
@@ -314,7 +316,7 @@ func TestFileIntegrityChangeGracePeriod(t *testing.T) {
 		t.Errorf("failed to retrieve FI object: %v\n", err)
 	}
 
-	newGracePeriod := common.DefaultGracePeriod * 2
+	newGracePeriod := 30
 	fileIntegrityCopy := fileIntegrity.DeepCopy()
 	fileIntegrityCopy.Spec = fileintv1alpha1.FileIntegritySpec{
 		Config: fileintv1alpha1.FileIntegrityConfig{

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -43,6 +43,7 @@ const (
 	testConfDataKey        = "conf"
 	nodeWorkerRoleLabelKey = "node-role.kubernetes.io/worker"
 	mcWorkerRoleLabelKey   = "machineconfiguration.openshift.io/role"
+	defaultTestGracePeriod = 20
 )
 
 var mcLabelForWorkerRole = map[string]string{
@@ -338,7 +339,9 @@ func setupTolerationTest(t *testing.T) (*framework.Framework, *framework.Context
 				// Schedule on the tainted host
 				corev1.LabelHostname: taintedNode.Labels[corev1.LabelHostname],
 			},
-			Config: fileintv1alpha1.FileIntegrityConfig{},
+			Config: fileintv1alpha1.FileIntegrityConfig{
+				GracePeriod: defaultTestGracePeriod,
+			},
 			Tolerations: []corev1.Toleration{
 				{
 					Key:      taintKey,
@@ -405,7 +408,9 @@ func setupTest(t *testing.T) (*framework.Framework, *framework.Context, string) 
 		},
 		Spec: fileintv1alpha1.FileIntegritySpec{
 			NodeSelector: nodeLabelForWorkerRole,
-			Config:       fileintv1alpha1.FileIntegrityConfig{},
+			Config: fileintv1alpha1.FileIntegrityConfig{
+				GracePeriod: defaultTestGracePeriod,
+			},
 		},
 	}
 	cleanupOptions := framework.CleanupOptions{
@@ -467,9 +472,10 @@ func updateFileIntegrityConfig(t *testing.T, f *framework.Framework, integrityNa
 		fileIntegrityCopy := fileIntegrity.DeepCopy()
 		fileIntegrityCopy.Spec = fileintv1alpha1.FileIntegritySpec{
 			Config: fileintv1alpha1.FileIntegrityConfig{
-				Name:      configMapName,
-				Namespace: namespace,
-				Key:       key,
+				Name:        configMapName,
+				Namespace:   namespace,
+				Key:         key,
+				GracePeriod: defaultTestGracePeriod,
 			},
 		}
 


### PR DESCRIPTION
The AIDE integrity checking is a very intensive process, with our
current default of 10s, the daemon would constantly take ~2.2G of memory
(for each instance... meaning, in each node).

This is excessive and will certainly raise alarms with folks running
this in production.

I propose to set our default grace period to be 900 (15 min), which
will result in the daemonsets taking 60MB when idle, and having usage
spikes every 15 mins.