### PR TITLE
api: Add description to spec.config keys to enable oc explain

### DIFF
--- a/deploy/crds/fileintegrity.openshift.io_fileintegrities_crd.yaml
+++ b/deploy/crds/fileintegrity.openshift.io_fileintegrities_crd.yaml
@@ -40,10 +40,17 @@ spec:
                     description: Time between individual aide scans
                     type: integer
                   key:
+                    description: The key that contains the actual AIDE configuration
+                      in a configmap specified by Name and Namespace. Defaults to
+                      aide.conf
                     type: string
                   name:
+                    description: Name of a configMap that contains custom AIDE configuration.
+                      A default configuration would be created if omitted.
                     type: string
                   namespace:
+                    description: Namespace of a configMap that contains custom AIDE
+                      configuration. A default configuration would be created if omitted.
                     type: string
                 type: object
               debug:

--- a/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
+++ b/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
@@ -38,9 +38,12 @@ type FileIntegritySpec struct {
 // FileIntegrityConfig defines the name, namespace, and data key for an AIDE config to use for integrity checking.
 // +k8s:openapi-gen=true
 type FileIntegrityConfig struct {
-	Name      string `json:"name,omitempty"`
+	// Name of a configMap that contains custom AIDE configuration. A default configuration would be created if omitted.
+	Name string `json:"name,omitempty"`
+	// Namespace of a configMap that contains custom AIDE configuration. A default configuration would be created if omitted.
 	Namespace string `json:"namespace,omitempty"`
-	Key       string `json:"key,omitempty"`
+	// The key that contains the actual AIDE configuration in a configmap specified by Name and Namespace. Defaults to aide.conf
+	Key string `json:"key,omitempty"`
 	// Time between individual aide scans
 	// +kubebuilder:default=900
 	GracePeriod int `json:"gracePeriod,omitempty"`


### PR DESCRIPTION
Wording suggestions welcome, in general having the strings available for oc explain increases usability.