### PR TITLE
FI: Label the DS, pods and FileIntegrityNodeStatus with owner label

### DIFF
--- a/cmd/manager/logcollector.go
+++ b/cmd/manager/logcollector.go
@@ -168,9 +168,9 @@ func getLogConfigMap(owner *unstructured.Unstructured, configMapName, contentkey
 				},
 			},
 			Labels: map[string]string{
-				common.IntegrityConfigMapOwnerLabelKey: owner.GetName(),
-				common.IntegrityLogLabelKey:            "",
-				common.IntegrityConfigMapNodeLabelKey:  node,
+				common.IntegrityOwnerLabelKey:         owner.GetName(),
+				common.IntegrityLogLabelKey:           "",
+				common.IntegrityConfigMapNodeLabelKey: node,
 			},
 		},
 		Data: map[string]string{
@@ -197,9 +197,9 @@ func getInformationalConfigMap(owner *unstructured.Unstructured, configMapName s
 				},
 			},
 			Labels: map[string]string{
-				common.IntegrityConfigMapOwnerLabelKey: owner.GetName(),
-				common.IntegrityLogLabelKey:            "",
-				common.IntegrityConfigMapNodeLabelKey:  node,
+				common.IntegrityOwnerLabelKey:         owner.GetName(),
+				common.IntegrityLogLabelKey:           "",
+				common.IntegrityConfigMapNodeLabelKey: node,
 			},
 		},
 	}

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -15,8 +15,8 @@ const (
 	IntegrityCMLabelKey = "file-integrity.openshift.io/cm"
 	// IntegrityLogResultLabelKey tells us that the configMap represents a result log (a log we decided to keep)
 	IntegrityLogResultLabelKey = "file-integrity.openshift.io/result-log"
-	// IntegrityConfigMapOwnerLabelKey tells us what FileIntegrity object owns a specific ConfigMap
-	IntegrityConfigMapOwnerLabelKey = "file-integrity.openshift.io/owner"
+	// IntegrityOwnerLabelKey tells us what FileIntegrity object owns a specific ConfigMap
+	IntegrityOwnerLabelKey = "file-integrity.openshift.io/owner"
 	// IntegrityConfigMapNodeLabelKey tells us from which node did the configmap come from
 	IntegrityConfigMapNodeLabelKey = "file-integrity.openshift.io/node"
 	// IntegrityLogContentKey is the key in the configmap where the logs are stored

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -72,7 +72,7 @@ func IsIntegrityLogAFailure(cm *corev1.ConfigMap) bool {
 // GetConfigMapOwnerName gets the name of the FileIntegrity that owns
 // the config map from the Labels
 func GetConfigMapOwnerName(cm *corev1.ConfigMap) (string, error) {
-	owner, ok := cm.Labels[IntegrityConfigMapOwnerLabelKey]
+	owner, ok := cm.Labels[IntegrityOwnerLabelKey]
 	if !ok {
 		return "", fmt.Errorf("ConfigMap '%s' had no owner label", cm.Name)
 	}

--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -256,6 +256,9 @@ func (r *ReconcileConfigMap) createOrUpdateNodeStatus(node string, instance *fil
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      instance.Name + "-" + node,
 				Namespace: instance.Namespace,
+				Labels: map[string]string{
+					common.IntegrityOwnerLabelKey: instance.Name,
+				},
 			},
 			NodeName: node,
 			Results:  []fileintegrityv1alpha1.FileIntegrityScanResult{},

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -548,6 +548,9 @@ func aideDaemonset(dsName string, fi *fileintegrityv1alpha1.FileIntegrity) *apps
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dsName,
 			Namespace: common.FileIntegrityNamespace,
+			Labels: map[string]string{
+				common.IntegrityOwnerLabelKey: fi.Name,
+			},
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
@@ -558,8 +561,9 @@ func aideDaemonset(dsName string, fi *fileintegrityv1alpha1.FileIntegrity) *apps
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":                       dsName,
-						common.IntegrityPodLabelKey: "",
+						"app":                         dsName,
+						common.IntegrityPodLabelKey:   "",
+						common.IntegrityOwnerLabelKey: fi.Name,
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
Renames common.IntegrityConfigMapOwnerLabelKey to a more generic names and
subsequently uses the the label for DS, pods and the resulting
FileIntegrityNodeStatus objects.

This way, the admin can easily list objects that relate to a single FI
object.