### PR TITLE
Bug 1826301: Mark the nodeStatus and the FI object as Error in case the config can't even be loaded

### DIFF
--- a/cmd/manager/daemon.go
+++ b/cmd/manager/daemon.go
@@ -287,6 +287,7 @@ func reinitLoop(rt *daemonRuntime, conf *daemonConfig, exit chan bool) {
 			if err := runAideInitDBCmd(); err != nil {
 				LOG(err.Error())
 				time.Sleep(time.Second)
+				rt.UnlockAideFiles("reinitLoop")
 				continue
 			}
 			LOG("initialization finished")
@@ -329,6 +330,7 @@ func reinitLoop(rt *daemonRuntime, conf *daemonConfig, exit chan bool) {
 			if err := runAideInitDBCmd(); err != nil {
 				LOG(err.Error())
 				time.Sleep(time.Second)
+				rt.UnlockAideFiles("reinitLoop")
 				continue
 			}
 

--- a/cmd/manager/daemon.go
+++ b/cmd/manager/daemon.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"sync"
-	"syscall"
 	"time"
 
 	"k8s.io/api/events/v1beta1"
@@ -233,18 +232,9 @@ func aideLoop(rt *daemonRuntime, conf *daemonConfig, exit chan bool) {
 		if !rt.Initializing() && !rt.Holding() {
 			rt.LockAideFiles("aideLoop")
 			LOG("running aide check")
-			exitStatus := 0
 			// This doesn't handle the output, because the operator ensures AIDE logs to /hostroot/etc/kubernetes/aide.log
 			err := runAideScanCmd()
-			if err != nil {
-				// This is a likely path as failed check results are in return codes range 1 - 7.
-				// Find the return code. The log collector loop will figure out if it's an error or not.
-				if exitErr, ok := err.(*exec.ExitError); ok {
-					if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-						exitStatus = status.ExitStatus()
-					}
-				}
-			}
+			exitStatus := common.GetAideExitCode(err)
 			LOG("aide check returned status %d", exitStatus)
 			rt.result <- exitStatus
 			rt.UnlockAideFiles("aideLoop")

--- a/cmd/manager/daemon.go
+++ b/cmd/manager/daemon.go
@@ -276,6 +276,8 @@ func reinitLoop(rt *daemonRuntime, conf *daemonConfig, exit chan bool) {
 			LOG("initializing aide")
 			if err := runAideInitDBCmd(); err != nil {
 				LOG(err.Error())
+				aideRv := common.GetAideExitCode(err)
+				reportError(fmt.Sprintf("Error initializing the AIDE DB: %s", common.GetAideErrorMessage(aideRv)), conf, rt)
 				time.Sleep(time.Second)
 				rt.UnlockAideFiles("reinitLoop")
 				continue

--- a/deploy/crds/fileintegrity.openshift.io_fileintegritynodestatuses_crd.yaml
+++ b/deploy/crds/fileintegrity.openshift.io_fileintegritynodestatuses_crd.yaml
@@ -26,6 +26,31 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          lastResult:
+            description: FileIntegrityScanResult defines the one-time result of a
+              scan.
+            properties:
+              condition:
+                type: string
+              errorMessage:
+                type: string
+              filesAdded:
+                type: integer
+              filesChanged:
+                type: integer
+              filesRemoved:
+                type: integer
+              lastProbeTime:
+                format: date-time
+                type: string
+              resultConfigMapName:
+                type: string
+              resultConfigMapNamespace:
+                type: string
+            required:
+            - condition
+            - lastProbeTime
+            type: object
           metadata:
             type: object
           nodeName:
@@ -58,6 +83,7 @@ spec:
               type: object
             type: array
         required:
+        - lastResult
         - nodeName
         - results
         type: object

--- a/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
+++ b/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
@@ -64,6 +64,7 @@ type FileIntegrityNodeStatus struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	NodeName          string                    `json:"nodeName"`
 	Results           []FileIntegrityScanResult `json:"results"`
+	LastResult        FileIntegrityScanResult   `json:"lastResult"`
 }
 
 // FileIntegrityScanResult defines the one-time result of a scan.

--- a/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
+++ b/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
@@ -14,6 +14,7 @@ const (
 	PhaseInitializing FileIntegrityStatusPhase = "Initializing"
 	PhaseActive       FileIntegrityStatusPhase = "Active"
 	PhasePending      FileIntegrityStatusPhase = "Pending"
+	PhaseError        FileIntegrityStatusPhase = "Error"
 )
 
 type FileIntegrityNodeCondition string

--- a/pkg/apis/fileintegrity/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/fileintegrity/v1alpha1/zz_generated.deepcopy.go
@@ -98,6 +98,7 @@ func (in *FileIntegrityNodeStatus) DeepCopyInto(out *FileIntegrityNodeStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	in.LastResult.DeepCopyInto(&out.LastResult)
 	return
 }
 

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -191,5 +191,41 @@ func getExitCode(runCmdErr error, defaultError int) int {
 }
 
 func GetAideExitCode(runCmdError error) int {
-	return getExitCode(runCmdError, 99)
+	return getExitCode(runCmdError, aideErrSentinel)
+}
+
+const aideErrBase = 14
+
+const (
+	aideErrWriteErr = iota + aideErrBase
+	aideErrEinval
+	aideErrNotImplemented
+	aideErrConfig
+	aideErrIO
+	aideErrVersionMismatch
+	// This is FIO addition
+	aideErrSentinel
+)
+
+var aideErrLookup = []struct {
+	errCode   int
+	errString string
+}{
+	{aideErrWriteErr, "Error writing error"},
+	{aideErrEinval, "Invalid argument error"},
+	{aideErrNotImplemented, "Unimplemented function error"},
+	{aideErrConfig, "Invalid configureline error"},
+	{aideErrIO, "IO error"},
+	{aideErrVersionMismatch, "Version mismatch error"},
+	{aideErrSentinel, "Unexpected error"},
+}
+
+func GetAideErrorMessage(rv int) string {
+	if rv < aideErrBase || rv > aideErrSentinel {
+		// default to the sentinel error message for unknown or unexpected errors
+		rv = aideErrSentinel
+	}
+
+	rv -= aideErrBase // the array index still starts at zero...
+	return aideErrLookup[rv].errString
 }

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -2,8 +2,10 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -160,4 +162,34 @@ func deleteDaemonSetPods(c client.Client, ds *appsv1.DaemonSet) error {
 	}
 
 	return nil
+}
+
+// getExitCode examines the error interface as returned from exec.Command().Run()
+// and returns 0 if the command succeeded, the command's return code if it ran to completion
+// but failed and a default error otherwise (e.g. on exit because of a signal)
+//
+// requires go 1.13 or newer due to using errors.As() and ExitCode
+func getExitCode(runCmdErr error, defaultError int) int {
+	// No error, awesome, the command exited successfully
+	if runCmdErr == nil {
+		return 0
+	}
+
+	var exitError *exec.ExitError
+	if errors.As(runCmdErr, &exitError) {
+		// ExitError.ExitCode() return the error code if the command produced any or -1
+		// if the command exited for another reason (signal, ...)
+		rv := exitError.ExitCode()
+		if rv != -1 {
+			return rv
+		}
+		// fall back to returning defaultError
+	}
+	// if the error is something else then exec.ExitError, just return the defaultError
+
+	return defaultError
+}
+
+func GetAideExitCode(runCmdError error) int {
+	return getExitCode(runCmdError, 99)
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -418,6 +418,25 @@ func TestFileIntegrityChangeDebug(t *testing.T) {
 	}
 }
 
+func TestFileIntegrityBadConfig(t *testing.T) {
+	f, testctx, namespace := setupTest(t)
+	defer testctx.Cleanup()
+	defer func() {
+		if err := cleanNodes(f, namespace); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Install the different config
+	createTestConfigMap(t, f, testIntegrityName, testConfName, namespace, testConfDataKey, brokenAideConfig)
+
+	// wait to go to error state.
+	err := waitForScanStatusWithTimeout(t, f, namespace, testIntegrityName, fileintv1alpha1.PhaseError, retryInterval, timeout, 1)
+	if err != nil {
+		t.Errorf("Timeout waiting for scan status")
+	}
+}
+
 func TestFileIntegrityTolerations(t *testing.T) {
 	f, testctx, namespace := setupTolerationTest(t)
 	defer testctx.Cleanup()

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -90,6 +90,8 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 # Catch everything else in /etc
 /hostroot/etc/    CONTENT_EX`
 
+var brokenAideConfig = testAideConfig + "\n" + "NORMAL = p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha513+md5+XXXXXX"
+
 func cleanUp(t *testing.T, namespace string) func() error {
 	return func() error {
 		f := framework.Global

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -578,12 +578,9 @@ func waitForFailedResultForNode(t *testing.T, f *framework.Framework, namespace,
 
 		t.Logf("waitForFailedResultForNode: found nodeStatus: %#v", nodeStatus)
 
-		for i, _ := range nodeStatus.Results {
-			t.Logf("dbg: wait for fail, result %#v", nodeStatus.Results[i])
-			if nodeStatus.Results[i].Condition == fileintv1alpha1.NodeConditionFailed {
-				foundResult = &nodeStatus.Results[i]
-				return true, nil
-			}
+		if nodeStatus.LastResult.Condition == fileintv1alpha1.NodeConditionFailed {
+			foundResult = &nodeStatus.LastResult
+			return true, nil
 		}
 		return false, nil
 	})
@@ -622,22 +619,9 @@ func assertNodesConditionIsSuccess(t *testing.T, f *framework.Framework, namespa
 
 			t.Logf("assertNodesConditionIsSuccess: found nodeStatus: %#v", fileIntegNodeStatus)
 
-			// gather statuses
-			for _, status := range fileIntegNodeStatus.Results {
-				t.Logf("dbg: wait for success %#v", status)
-				t.Logf("Iterating through statuses: Found node status: %s - %s", fileIntegNodeStatus.NodeName, status.Condition)
-				recordedStatus, ok := latestStatuses[fileIntegNodeStatus.NodeName]
-				if !ok {
-					latestStatuses[fileIntegNodeStatus.NodeName] = nodeStatus{
-						LastProbeTime: status.LastProbeTime,
-						Condition:     status.Condition,
-					}
-				} else if recordedStatus.LastProbeTime.Before(&status.LastProbeTime) {
-					latestStatuses[fileIntegNodeStatus.NodeName] = nodeStatus{
-						LastProbeTime: status.LastProbeTime,
-						Condition:     status.Condition,
-					}
-				}
+			latestStatuses[fileIntegNodeStatus.NodeName] = nodeStatus{
+				LastProbeTime: fileIntegNodeStatus.LastResult.LastProbeTime,
+				Condition:     fileIntegNodeStatus.LastResult.Condition,
 			}
 		}
 


### PR DESCRIPTION
In case the configuration was wrong, the reinitLoop function would just
continue its loop, but because each loop tries to acquire the aideFiles
mutex, subsequent loops would just deadlock waiting on a mutex they
locked themselves.

To make sure the admin is notified about this, we watch for aide error conditions and put their string representation as a result to the fileIntegrityNodeStatus.

The fileIntegrityNodeStatus API is also extended with a lastResult attribute. This is the Result attribute with the latest timestamp. The reason I added the new attribute is that 1) it is easier this way to check if the "current" status is an error which is what the next patch does and 2) it will be useful in order to provide custom column printers

Finally, the status controller is extended so that if any of the fileIntegrityNodeStatus objects' lastResult is an Error, then the FI status as a whole is also an error so that the admin is notified that the FI does not work.