### PR TITLE
daemon: Shortcut the integrityInstanceLoop if a watch can't be found

### DIFF
--- a/cmd/manager/daemon.go
+++ b/cmd/manager/daemon.go
@@ -377,6 +377,7 @@ func integrityInstanceLoop(rt *daemonRuntime, conf *daemonConfig, exit chan bool
 	if err != nil {
 		DBG("Couldn't get file integrity object: %s", conf.FileIntegrityName)
 		exit <- true
+		return
 	}
 
 	listopts := metav1.ListOptions{
@@ -386,6 +387,7 @@ func integrityInstanceLoop(rt *daemonRuntime, conf *daemonConfig, exit chan bool
 	if err != nil {
 		DBG("Couldn't watch file integrity object: %s", conf.FileIntegrityName)
 		exit <- true
+		return
 	}
 	ch := watcher.ResultChan()
 	for event := range ch {


### PR DESCRIPTION
Especially in the case the watch command fails, the watcher variable
would have been nil and while we write to the exit channel to signal
that the daemon should quit, we would still continue in the
integrityInstanceLoop goroutine and potentially dereference the nil
value.

Let's cleanly exit from the goroutine instead.