### PR TITLE
Remove replaces: from CSV

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -10,9 +10,7 @@ COPY . .
 RUN make operator-bin
 
 # Step two: containerize file-integrity-operator and AIDE together
-# FROM registry.access.redhat.com/ubi8/ubi:latest
-# Use temporarily until AIDE is in ubi
-FROM centos:centos7
+FROM registry.centos.org/centos:8
 RUN yum -y install aide && yum clean all
 
 ENV OPERATOR=/usr/local/bin/file-integrity-operator \

--- a/cmd/manager/logcollector.go
+++ b/cmd/manager/logcollector.go
@@ -284,7 +284,8 @@ func logCollectorMainLoop(rt *daemonRuntime, conf *daemonConfig, ch chan bool) {
 	for {
 		lastResult := <-rt.result
 		// We haven't received a result yet.
-		if lastResult == -1 {
+		// Or return code 18 - AIDE ran prior to there being an aide database.
+		if lastResult == -1 || lastResult == 18 {
 			DBG("No scan result available")
 			time.Sleep(time.Duration(conf.Interval) * time.Second)
 			continue

--- a/cmd/manager/logcollector.go
+++ b/cmd/manager/logcollector.go
@@ -118,9 +118,9 @@ func matchFileChangeRegex(contents []byte, regex string) string {
 }
 
 func annotateFileChangeSummary(contents []byte, annotations map[string]string) {
-	annotations[common.IntegrityLogFilesAddedAnnotation] = matchFileChangeRegex(contents, `\s+Added files:\s+(?P<num_added>\d+)`)
-	annotations[common.IntegrityLogFilesChangedAnnotation] = matchFileChangeRegex(contents, `\s+Changed files:\s+(?P<num_changed>\d+)`)
-	annotations[common.IntegrityLogFilesRemovedAnnotation] = matchFileChangeRegex(contents, `\s+Removed files:\s+(?P<num_removed>\d+)`)
+	annotations[common.IntegrityLogFilesAddedAnnotation] = matchFileChangeRegex(contents, `\s+Added entries:\s+(?P<num_added>\d+)`)
+	annotations[common.IntegrityLogFilesChangedAnnotation] = matchFileChangeRegex(contents, `\s+Changed entries:\s+(?P<num_changed>\d+)`)
+	annotations[common.IntegrityLogFilesRemovedAnnotation] = matchFileChangeRegex(contents, `\s+Removed entries:\s+(?P<num_removed>\d+)`)
 	DBG("added %s changed %s removed %s",
 		annotations[common.IntegrityLogFilesAddedAnnotation],
 		annotations[common.IntegrityLogFilesChangedAnnotation],

--- a/deploy/olm-catalog/file-integrity-operator/0.1.5/file-integrity-operator.v0.1.5.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/file-integrity-operator/0.1.5/file-integrity-operator.v0.1.5.clusterserviceversion.yaml
@@ -197,5 +197,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: file-integrity-operator.v0.1.4
   version: 0.1.5


### PR DESCRIPTION
This file is sourced for the downstream bundle builds now. Since the downstream bundle builds specify a single release it errors out on the replaces: line. 