### PR TITLE
Reload FI when the configMap the FI points to changes

### DIFF
--- a/pkg/controller/fileintegrity/cm_to_fi_mapper.go
+++ b/pkg/controller/fileintegrity/cm_to_fi_mapper.go
@@ -1,0 +1,45 @@
+package fileintegrity
+
+import (
+	"context"
+	fileintegrityv1alpha1 "github.com/openshift/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type fileIntegrityMapper struct {
+	client.Client
+}
+
+func (s *fileIntegrityMapper) Map(obj handler.MapObject) []reconcile.Request {
+	var requests []reconcile.Request
+
+	fiList := fileintegrityv1alpha1.FileIntegrityList{}
+	err := s.List(context.TODO(), &fiList, &client.ListOptions{})
+	if err != nil {
+		return requests
+	}
+
+	for _, fi := range fiList.Items {
+		if fi.Spec.Config.Name != obj.Meta.GetName() {
+			continue
+		}
+
+		if fi.Spec.Config.Namespace != obj.Meta.GetNamespace() {
+			continue
+		}
+
+		objKey := types.NamespacedName{
+			Name:      fi.GetName(),
+			Namespace: fi.GetNamespace(),
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: objKey})
+		log.Info("Will reconcile FI because its config changed",
+			"configMap.Name", obj.Meta.GetName(), "configMap.Namespace",
+			obj.Meta.GetNamespace(), "fileIntegrity.Name", fi.Name, "fileIntegrity.Namespace", fi.Namespace)
+	}
+
+	return requests
+}

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -54,6 +54,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to configMaps that are used by a FI instance. We use a mapper to map the CM to FI
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: &fileIntegrityMapper{mgr.GetClient()},
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -434,12 +434,21 @@ func TestFileIntegrityBadConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
+	defer logContainerOutput(t, f, namespace, testIntegrityName)
 
 	// Install the different config
 	createTestConfigMap(t, f, testIntegrityName, testConfName, namespace, testConfDataKey, brokenAideConfig)
 
 	// wait to go to error state.
 	err := waitForScanStatusWithTimeout(t, f, namespace, testIntegrityName, fileintv1alpha1.PhaseError, retryInterval, timeout, 1)
+	if err != nil {
+		t.Errorf("Timeout waiting for scan status")
+	}
+
+	// Fix the config
+	updateTestConfigMap(t, f, testConfName, namespace, testConfDataKey, testAideConfig)
+	// wait to go to active state.
+	err = waitForScanStatusWithTimeout(t, f, namespace, testIntegrityName, fileintv1alpha1.PhaseActive, retryInterval, timeout, 1)
 	if err != nil {
 		t.Errorf("Timeout waiting for scan status")
 	}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -542,6 +542,20 @@ func createTestConfigMap(t *testing.T, f *framework.Framework, integrityName, co
 	updateFileIntegrityConfig(t, f, integrityName, configMapName, namespace, key, time.Second, 2*time.Minute)
 }
 
+func updateTestConfigMap(t *testing.T, f *framework.Framework, configMapName, namespace, key, data string) {
+	// update the test AIDE configmap
+	cm, err := f.KubeClient.CoreV1().ConfigMaps(namespace).Get(goctx.TODO(), configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	cm.Data[key] = data
+	_, err = f.KubeClient.CoreV1().ConfigMaps(namespace).Update(goctx.TODO(), cm, metav1.UpdateOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func waitForScanStatusWithTimeout(t *testing.T, f *framework.Framework, namespace, name string, targetStatus fileintv1alpha1.FileIntegrityStatusPhase, interval, timeout time.Duration, successiveResults int) error {
 	exampleFileIntegrity := &fileintv1alpha1.FileIntegrity{}
 	resultNum := 0


### PR DESCRIPTION
The FI controller used to only watch for FI object changes. That meant
that if the configMap pointed to by spec.config changed, the operator
would not re-render the configuration the DS uses until the FI object
was 'touched'.

This patch uses a custom mapper to reconcile FI objects when CMs that
are used by a FI changes.