### PR TITLE
Remove `-race` flag from manager build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ build: operator-bin ## Build the file-integrity-operator binaries
 
 .PHONY: operator-bin
 operator-bin:
-	$(GO) build -race -o $(TARGET_OPERATOR) github.com/openshift/file-integrity-operator/cmd/manager
+	$(GO) build -o $(TARGET_OPERATOR) github.com/openshift/file-integrity-operator/cmd/manager
 
 .PHONY: operator-sdk
 operator-sdk: $(GOPATH)/bin/operator-sdk


### PR DESCRIPTION
The overhead is not worth it.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>