### PR TITLE
Bug 1921692: Add status columns to fileintegritynodestatus output

### DIFF
--- a/deploy/crds/fileintegrity.openshift.io_fileintegritynodestatuses_crd.yaml
+++ b/deploy/crds/fileintegrity.openshift.io_fileintegritynodestatuses_crd.yaml
@@ -11,7 +11,14 @@ spec:
     singular: fileintegritynodestatus
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .nodeName
+      name: Node
+      type: string
+    - jsonPath: .lastResult.condition
+      name: Status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: FileIntegrityNodeStatus defines the status of a specific node
@@ -89,3 +96,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/deploy/olm-catalog/file-integrity-operator/manifests/fileintegrity.openshift.io_fileintegrities_crd.yaml
+++ b/deploy/olm-catalog/file-integrity-operator/manifests/fileintegrity.openshift.io_fileintegrities_crd.yaml
@@ -1,7 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: fileintegrities.fileintegrity.openshift.io
 spec:
   group: fileintegrity.openshift.io
@@ -119,9 +118,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/deploy/olm-catalog/file-integrity-operator/manifests/fileintegrity.openshift.io_fileintegritynodestatuses_crd.yaml
+++ b/deploy/olm-catalog/file-integrity-operator/manifests/fileintegrity.openshift.io_fileintegritynodestatuses_crd.yaml
@@ -1,7 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: fileintegritynodestatuses.fileintegrity.openshift.io
 spec:
   group: fileintegrity.openshift.io
@@ -12,7 +11,14 @@ spec:
     singular: fileintegritynodestatus
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .nodeName
+      name: Node
+      type: string
+    - jsonPath: .lastResult.condition
+      name: Status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: FileIntegrityNodeStatus defines the status of a specific node
@@ -90,9 +96,4 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
+    subresources: {}

--- a/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
+++ b/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
@@ -60,6 +60,8 @@ type FileIntegrityStatus struct {
 
 // FileIntegrityNodeStatus defines the status of a specific node
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="Node",type="string",JSONPath=`.nodeName`
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.lastResult.condition`
 type FileIntegrityNodeStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This shows the latest status for a node: 
```
$ oc get fileintegritynodestatuses                                                       
NAME                                                NODE                          STATUS
example-fileintegrity-ip-10-0-128-75.ec2.internal   ip-10-0-128-75.ec2.internal   Succeeded
```
