### PR TITLE
Bug 1923096: Update nodeSelector and Tolerations

### DIFF
--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -411,7 +411,7 @@ func updateDSImage(currentDS *appsv1.DaemonSet, logger logr.Logger) bool {
 	expectedImg := common.GetComponentImage(common.OPERATOR)
 	needsUpdate := *currentImgRef != expectedImg
 	if needsUpdate {
-		logger.Info("FileIntegrity needed image update")
+		logger.Info("FileIntegrity needed image update", "Expected-Image", expectedImg, "Current-Image", currentImgRef)
 		*currentImgRef = expectedImg
 	}
 	return needsUpdate

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -207,6 +207,7 @@ func TestFileIntegrityConfigurationIgnoreMissing(t *testing.T) {
 	defer logContainerOutput(t, f, namespace, testIntegrityName)
 
 	// Non-existent conf
+	t.Log("Updating file integrity with non-existent user-config")
 	updateFileIntegrityConfig(t, f, testIntegrityName, "fooconf", namespace, "fookey", time.Second, 2*time.Minute)
 
 	// No re-init should happen, let this error pass.


### PR DESCRIPTION
If the `nodeSelector` or `tolerations` sections of the `FileIntegrity` object were updated, these changes wouldn't reflect on the resulting operand (the DaemonSet). This fixes that.

Extra logging is added to be able to debug what is being updated.