### PR TITLE
Adds note about configMap annotation indicating compression of AIDE logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Detailed information about changes:
 File: /hostroot/etc/resolv.conf
  SHA512   : Xl2pzxjmRPtW8bl6Kj49SkKOSBVJgsCI , tebxD8QZd/5/SqsVkExCwVqVO22zxmcq
 ```
-AIDE logs over 1mb are gzip compressed and base64 encoded, due to the configMap data size limit. In this case, you will want to pipe the output of the above command to `base64 -d | gunzip`.
+AIDE logs over 1MB are gzip compressed and base64 encoded, due to the configMap data size limit. In this case, you will want to pipe the output of the above command to `base64 -d | gunzip`.  Compressed logs are indicated by the presense of a `file-integrity.openshift.io/compressed` annotation key in the configMap.
 
 ### Local testing
 ```


### PR DESCRIPTION
Adds a note to the README.md section on comression of AIDE logs to indicate the presense of the `file-integrity.openshift.io/compressed` annotation if the logs are compressed. This annotation will be helpful in determining with automation if the logs are compressed or not.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>