### PR TITLE
logcollector: Only read log once in a buffered way

### DIFF
--- a/cmd/manager/daemon.go
+++ b/cmd/manager/daemon.go
@@ -102,18 +102,17 @@ type daemonConfig struct {
 }
 
 type daemonRuntime struct {
-	clientset              *kubernetes.Clientset
-	dynclient              dynamic.Interface
-	logCollectorInode      uint64
-	logCollectorReadoffset int64
-	initializing           bool
-	initializingMux        sync.Mutex
-	holding                bool
-	holdingMux             sync.Mutex
-	result                 chan int
-	dbMux                  sync.Mutex
-	fiInstance             *unstructured.Unstructured
-	instanceMux            sync.Mutex
+	clientset         *kubernetes.Clientset
+	dynclient         dynamic.Interface
+	logCollectorInode uint64
+	initializing      bool
+	initializingMux   sync.Mutex
+	holding           bool
+	holdingMux        sync.Mutex
+	result            chan int
+	dbMux             sync.Mutex
+	fiInstance        *unstructured.Unstructured
+	instanceMux       sync.Mutex
 }
 
 func (rt *daemonRuntime) Initializing() bool {
@@ -240,8 +239,9 @@ func daemonMainLoop(cmd *cobra.Command, args []string) {
 	}
 
 	rt := &daemonRuntime{
-		clientset: clientset,
-		dynclient: dynclient,
+		clientset:         clientset,
+		dynclient:         dynclient,
+		logCollectorInode: 0,
 	}
 
 	rt.result = make(chan int, 50)


### PR DESCRIPTION
Instead of reading the whole file and executing operations on top of
that loaded file. This loads the reader interface on to a buffered
reader and passes that around; thus only reading the file when it's
really needed (for compression or writing).

This also removes the offset tracking, which wasn't being used since
AIDE truncates the log file before writing it.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>