### PR TITLE
Bug 1925105: Fix madvise setting

### DIFF
--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -607,7 +607,7 @@ func aideDaemonset(dsName string, fi *fileintegrityv1alpha1.FileIntegrity) *apps
 								{
 									// Needed for friendlier memory reporting as long as we are on golang < 1.16
 									Name:  "GODEBUG",
-									Value: "madvisedontneed=1",
+									Value: "madvdontneed=1",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
The option is `GODEBUG=madvdontneed=1` not `GODEBUG=madvisedontneed=1`