### PR TITLE
Bug 1943475: Compression fixes

### DIFF
--- a/cmd/manager/daemon.go
+++ b/cmd/manager/daemon.go
@@ -253,13 +253,12 @@ func daemonMainLoop(cmd *cobra.Command, args []string) {
 	reinitLoopDone := make(chan bool)
 	holdOffLoopDone := make(chan bool)
 	aideLoopDone := make(chan bool)
-	logCollectorLoopDone := make(chan bool)
 	integrityInstanceLoopDone := make(chan bool)
 	go integrityInstanceLoop(rt, conf, integrityInstanceLoopDone)
 	go reinitLoop(rt, conf, reinitLoopDone)
 	go holdOffLoop(rt, conf, holdOffLoopDone)
 	go aideLoop(rt, conf, aideLoopDone)
-	go logCollectorMainLoop(rt, conf, logCollectorLoopDone)
+	go logCollectorMainLoop(rt, conf)
 
 	// At the moment only reinitLoop exits fatally,
 	select {
@@ -269,8 +268,6 @@ func daemonMainLoop(cmd *cobra.Command, args []string) {
 		FATAL("%v", fmt.Errorf("holdoff loop errored"))
 	case <-aideLoopDone:
 		FATAL("%v", fmt.Errorf("aide errored"))
-	case <-logCollectorLoopDone:
-		FATAL("%v", fmt.Errorf("log-collector errored"))
 	case <-integrityInstanceLoopDone:
 		FATAL("%v", fmt.Errorf("instance watcher errored"))
 	}

--- a/cmd/manager/daemon.go
+++ b/cmd/manager/daemon.go
@@ -244,10 +244,10 @@ func daemonMainLoop(cmd *cobra.Command, args []string) {
 		logCollectorInode: 0,
 	}
 
+	// A note about the initial state: since a buffered channel's recv (logCollectorMainLoop()'s last-result input)
+	// blocks when the buffer is empty, we want it empty to start with. We used to load rt.result with -1 to avoid a
+	// race, but now we need to do the opposite.
 	rt.result = make(chan int, 50)
-
-	// Set initial states so the loops do not race in the beginning.
-	rt.result <- -1
 	rt.SetInitializing("main", false)
 
 	reinitLoopDone := make(chan bool)

--- a/cmd/manager/logcollector.go
+++ b/cmd/manager/logcollector.go
@@ -285,7 +285,7 @@ func uploadLog(contents, compressedContents []byte, conf *daemonConfig, rt *daem
 
 // logCollectorMainLoop creates temporary status report configMaps for the configmap controller to pick up and turn
 // into permanent ones. It reads the last result reported from aide.
-func logCollectorMainLoop(rt *daemonRuntime, conf *daemonConfig, ch chan bool) {
+func logCollectorMainLoop(rt *daemonRuntime, conf *daemonConfig) {
 	for {
 		lastResult := <-rt.result
 		// We haven't received a result yet.

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -522,6 +522,7 @@ func updateFileIntegrityConfig(t *testing.T, f *framework.Framework, integrityNa
 		}
 		fileIntegrityCopy := fileIntegrity.DeepCopy()
 		fileIntegrityCopy.Spec = fileintv1alpha1.FileIntegritySpec{
+			NodeSelector: nodeLabelForWorkerRole,
 			Config: fileintv1alpha1.FileIntegrityConfig{
 				Name:        configMapName,
 				Namespace:   namespace,

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -642,10 +642,10 @@ func waitForFailedResultForNode(t *testing.T, f *framework.Framework, namespace,
 			return false, nil
 		}
 
-		t.Logf("waitForFailedResultForNode: found nodeStatus: %#v", nodeStatus)
-
 		if nodeStatus.LastResult.Condition == fileintv1alpha1.NodeConditionFailed {
 			foundResult = &nodeStatus.LastResult
+			t.Logf("failed result for node %s found, r:%d a:%d c:%d", node, foundResult.FilesRemoved,
+				foundResult.FilesAdded, foundResult.FilesChanged)
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
* Fix a crash due to passing a nil Reader to compress().
* Create a proper status when compression is needed.
* A compressed log may still be over the limit, in which case add a warning to the configMap to fetch the log manually.
* Removes the initial AIDE result when starting up to avoid a race with the AIDE loop and re-init loop.
* Compression e2e's
