### PR TITLE
Exclude the CNI plugin directory

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -44,6 +44,7 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 !/hostroot/etc/docker/certs.d
 !/hostroot/etc/selinux/targeted
 !/hostroot/etc/openvswitch/conf.db
+!/hostroot/etc/kubernetes/cni/net.d/*
 
 # Catch everything else in /etc
 /hostroot/etc/    CONTENT_EX`

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -91,6 +91,7 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 !/hostroot/etc/docker/certs.d
 !/hostroot/etc/selinux/targeted
 !/hostroot/etc/openvswitch/conf.db
+!/hostroot/etc/kubernetes/cni/net.d/*
 
 # Catch everything else in /etc
 /hostroot/etc/    CONTENT_EX`


### PR DESCRIPTION
This stops /etc/kubernetes/cni/net.d/ from being covered under scans with the
default config.