### PR TITLE
Move test-specific permissions out of deploy manifests

### DIFF
--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -10,39 +10,6 @@ metadata:
   name: file-integrity-daemon
   namespace: openshift-file-integrity
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: fio-metrics-client
-rules:
-  - nonResourceURLs:
-      - /metrics
-      - /metrics-fio
-    verbs:
-      - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: fio-metrics-client
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: fio-metrics-client
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: openshift-file-integrity
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: metrics-token
-  namespace: openshift-file-integrity
-  annotations:
-    kubernetes.io/service-account.name: default
-type: kubernetes.io/service-account-token
----
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
We only need the rules and stuff for fio-metrics-client while testing, and not normal deploys.