### PR TITLE
Release v0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.17] - 2021-08-05
+### Changes
+- Move test-specific permissions out of deploy manifests
+- Use latest for CSV documentation link
+- Enable TLS for controller metrics
+- vendor deps
+- Add controller-based Prometheus metrics
+- Update ignition and MCO dependencies
+- Update gosec and fix warnings
+
 ## [0.1.16] - 2021-06-02
 ### Changes
 - Handle AIDE error code 255

--- a/deploy/olm-catalog/file-integrity-operator/manifests/file-integrity-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/file-integrity-operator/manifests/file-integrity-operator.clusterserviceversion.yaml
@@ -19,12 +19,12 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.6 <0.1.16'
+    olm.skipRange: '>=0.1.6 <0.1.17'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-file-integrity
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/openshift/file-integrity-operator
-  name: file-integrity-operator.v0.1.16
+  name: file-integrity-operator.v0.1.17
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -86,8 +86,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: file-integrity-operator
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/file-integrity-operator/file-integrity-operator:0.1.16
-                image: quay.io/file-integrity-operator/file-integrity-operator:0.1.16
+                  value: quay.io/file-integrity-operator/file-integrity-operator:0.1.17
+                image: quay.io/file-integrity-operator/file-integrity-operator:0.1.17
                 imagePullPolicy: Always
                 name: file-integrity-operator
                 resources:
@@ -97,6 +97,10 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 10Mi
+                volumeMounts:
+                - mountPath: /var/run/secrets/serving-cert
+                  name: serving-cert
+                  readOnly: true
               nodeSelector:
                 node-role.kubernetes.io/master: ""
               serviceAccountName: file-integrity-operator
@@ -112,6 +116,10 @@ spec:
                 key: node.kubernetes.io/not-ready
                 operator: Exists
                 tolerationSeconds: 120
+              volumes:
+              - name: serving-cert
+                secret:
+                  secretName: file-integrity-operator-serving-cert
       permissions:
       - rules:
         - apiGroups:
@@ -142,6 +150,13 @@ spec:
           - servicemonitors
           verbs:
           - get
+          - create
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
           - create
         - apiGroups:
           - apps
@@ -209,6 +224,18 @@ spec:
           - create
           - update
         serviceAccountName: file-integrity-daemon
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: prometheus-k8s
     strategy: deployment
   installModes:
   - supported: true
@@ -234,4 +261,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/openshift/file-integrity-operator
-  version: 0.1.16
+  version: 0.1.17


### PR DESCRIPTION
## [0.1.17] - 2021-08-05
### Changes
- Move test-specific permissions out of deploy manifests
- Use latest for CSV documentation link
- Enable TLS for controller metrics
- vendor deps
- Add controller-based Prometheus metrics
- Update ignition and MCO dependencies
- Update gosec and fix warnings