### PR TITLE
Bug 1862022: Per-node reinit during update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ E2E_USE_DEFAULT_IMAGES?=false
 # Pass extra flags to the e2e test run.
 # e.g. to run a specific test in the e2e test suite, do:
 # 	make e2e E2E_GO_TEST_FLAGS="-v -run TestE2E/TestScanWithNodeSelectorFiltersCorrectly"
-E2E_GO_TEST_FLAGS?=-v -timeout 45m
+E2E_GO_TEST_FLAGS?=-v -timeout 60m
 
 # operator-sdk arguments for `make release`.
 QUAY_NAMESPACE=file-integrity-operator

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -35,12 +35,12 @@ const (
 	PausePath                          = "/scripts/pause.sh"
 	AideScriptConfigMapPrefix          = "aide-script"
 	AideScriptPath                     = "/scripts/aide.sh"
-	DaemonSetPrefix                    = "aide-ds"
+	DaemonSetPrefix                    = "aide"
 	DefaultConfDataKey                 = "aide.conf"
 	AideScriptKey                      = "aide.sh"
 	OperatorServiceAccountName         = "file-integrity-operator"
 	DaemonServiceAccountName           = "file-integrity-daemon"
-	ReinitDaemonSetPrefix              = "aide-reinit-ds"
+	ReinitDaemonSetPrefix              = "aide-ini"
 	// IntegrityCheckHoldoffFilePath specified the path to the file that tells
 	// the AIDE check to hold off
 	IntegrityCheckHoldoffFilePath = "/hostroot/etc/kubernetes/holdoff"

--- a/pkg/common/name.go
+++ b/pkg/common/name.go
@@ -1,0 +1,40 @@
+package common
+
+// Crypto-unsafe name helper code borrowed from compliance-operator <3
+
+import (
+	// #nosec G505
+	"crypto/sha1"
+	"fmt"
+	"io"
+)
+
+// LengthName creates a string of maximum defined length.
+func LengthName(maxLen int, hashPrefix string, format string, a ...interface{}) (string, error) {
+	friendlyName := fmt.Sprintf(format, a...)
+	if len(friendlyName) < maxLen {
+		return friendlyName, nil
+	}
+
+	// If that's too long, just hash the name. It's not very user friendly, but whatever
+	//
+	// We can suppress the gosec warning about sha1 here because we don't use sha1 for crypto
+	// purposes, but only as a string shortener
+	// #nosec G401
+	hasher := sha1.New()
+	io.WriteString(hasher, friendlyName)
+	hashedName := hashPrefix + fmt.Sprintf("%x", hasher.Sum(nil))
+
+	if len(hashedName) >= maxLen {
+		return "", fmt.Errorf("Cannot shorten '%s' with prefix %s", friendlyName, hashPrefix)
+	}
+	return hashedName, nil
+}
+
+func DNSLengthName(hashPrefix string, format string, a ...interface{}) string {
+	const maxDNSLen = 64
+
+	// TODO(jaosorior): Handle error
+	name, _ := LengthName(maxDNSLen, hashPrefix, format, a...)
+	return name
+}

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -117,16 +117,22 @@ func GetScriptName(fiName string) string {
 	return AideScriptConfigMapPrefix + "-" + fiName
 }
 
-// GetDaemonSetName gets the name of the owner (usually a FileIntegrity CR) and
-// returns an appropriate name for the DaemonSet that's owned by it.
-func GetDaemonSetName(name string) string {
-	return DaemonSetPrefix + "-" + name
+// DaemonSetName returns a friendly name for the AIDE daemonSet
+func DaemonSetName(name string) string {
+	return DNSLengthName(DaemonSetPrefix, "%s-%s", DaemonSetPrefix, name)
 }
 
-// GetReinitDaemonSetName gets the name of the owner (usually a FileIntegrity CR) and
-// returns an appropriate name for the DaemonSet that's owned by it.
-func GetReinitDaemonSetName(name string) string {
-	return ReinitDaemonSetPrefix + "-" + name
+// ReinitDaemonSetName returns a friendly name for the re-init daemonSet
+func ReinitDaemonSetName(name string) string {
+	return DNSLengthName(ReinitDaemonSetPrefix, "%s-%s", ReinitDaemonSetPrefix, name)
+}
+
+// ReinitDaemonSetNodeName returns a friendly name for the re-init daemonSet for one node.
+func ReinitDaemonSetNodeName(name, node string) string {
+	if len(node) == 0 {
+		return ReinitDaemonSetName(name)
+	}
+	return DNSLengthName(ReinitDaemonSetPrefix, "%s-%s-%s", ReinitDaemonSetPrefix, name, node)
 }
 
 // RestartFileIntegrityDs restarts all pods that belong to a given DaemonSet. This can be

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -403,7 +403,7 @@ func TestFileIntegrityChangeGracePeriod(t *testing.T) {
 		t.Errorf("The old pods were not shut down\n")
 	}
 
-	dsName := common.GetDaemonSetName(testName)
+	dsName := common.DaemonSetName(testName)
 	err = waitForDaemonSet(daemonSetIsReady(f.KubeClient, dsName, namespace))
 	if err != nil {
 		t.Errorf("Timed out waiting for DaemonSet %s", dsName)
@@ -474,7 +474,7 @@ func TestFileIntegrityChangeDebug(t *testing.T) {
 		t.Errorf("The old pods were not shut down\n")
 	}
 
-	dsName := common.GetDaemonSetName(testName)
+	dsName := common.DaemonSetName(testName)
 	err = waitForDaemonSet(daemonSetIsReady(f.KubeClient, dsName, namespace))
 	if err != nil {
 		t.Errorf("Timed out waiting for DaemonSet %s", dsName)
@@ -657,5 +657,5 @@ func TestFileIntegrityAcceptsExpectedChange(t *testing.T) {
 	}
 
 	t.Log("Asserting that the FileIntegrity check is in a SUCCESS state after expected changes")
-	assertNodesConditionIsSuccess(t, f, testName, namespace, 5*time.Second, 5*time.Minute)
+	assertNodesConditionIsSuccess(t, f, testName, namespace, 5*time.Second, 10*time.Minute)
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -301,7 +301,7 @@ func setupFileIntegrity(t *testing.T, f *framework.Framework, testCtx *framework
 
 	t.Logf("Created FileIntegrity: %+v", testIntegrityCheck)
 
-	dsName := common.GetDaemonSetName(testIntegrityCheck.Name)
+	dsName := common.DaemonSetName(testIntegrityCheck.Name)
 	err = waitForDaemonSet(daemonSetIsReady(f.KubeClient, dsName, namespace))
 	if err != nil {
 		t.Fatalf("Timed out waiting for DaemonSet %s", dsName)
@@ -566,7 +566,7 @@ func setupTolerationTest(t *testing.T, integrityName string) (*framework.Framewo
 		t.Errorf("could not create fileintegrity object: %v", err)
 	}
 
-	dsName := common.GetDaemonSetName(testIntegrityCheck.Name)
+	dsName := common.DaemonSetName(testIntegrityCheck.Name)
 	err = waitForDaemonSet(daemonSetIsReady(f.KubeClient, dsName, namespace))
 	if err != nil {
 		t.Errorf("Timed out waiting for DaemonSet %s", dsName)
@@ -1139,7 +1139,7 @@ func isNodeReady(node corev1.Node) bool {
 
 func assertDSPodHasArg(t *testing.T, f *framework.Framework, fiName, namespace, expectedLine string, interval, timeout time.Duration) error {
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		ds, getErr := f.KubeClient.AppsV1().DaemonSets(namespace).Get(goctx.TODO(), common.GetDaemonSetName(fiName), metav1.GetOptions{})
+		ds, getErr := f.KubeClient.AppsV1().DaemonSets(namespace).Get(goctx.TODO(), common.DaemonSetName(fiName), metav1.GetOptions{})
 		if getErr != nil {
 			t.Logf("Retrying. Got error: %v\n", getErr)
 			return false, nil
@@ -1155,7 +1155,7 @@ func assertDSPodHasArg(t *testing.T, f *framework.Framework, fiName, namespace, 
 }
 
 func getFiDsPods(f *framework.Framework, fileIntegrityName, namespace string) (*corev1.PodList, error) {
-	dsName := common.GetDaemonSetName(fileIntegrityName)
+	dsName := common.DaemonSetName(fileIntegrityName)
 	ds, err := f.KubeClient.AppsV1().DaemonSets(namespace).Get(goctx.TODO(), dsName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Make re-init daemonSets apply to a single node at a time when going through a
node update. This fixes the issue where all nodes are re-initialized each time
a single node updates.