### PR TITLE
Release v0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.18] - 2021-08-20
+### Changes
+- Optimize per-node reinit calls
+- Handle metrics service during operator start
+- Bug 1862022: Per-node reinit during update
+- Update Dockerfile.ci goland and base image
+- Use fedora-minimal:34 base image
+
 ## [0.1.17] - 2021-08-05
 ### Changes
 - Move test-specific permissions out of deploy manifests

--- a/deploy/olm-catalog/file-integrity-operator/manifests/file-integrity-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/file-integrity-operator/manifests/file-integrity-operator.clusterserviceversion.yaml
@@ -19,12 +19,12 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.6 <0.1.17'
+    olm.skipRange: '>=0.1.6 <0.1.18'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-file-integrity
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/openshift/file-integrity-operator
-  name: file-integrity-operator.v0.1.17
+  name: file-integrity-operator.v0.1.18
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -86,8 +86,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: file-integrity-operator
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/file-integrity-operator/file-integrity-operator:0.1.17
-                image: quay.io/file-integrity-operator/file-integrity-operator:0.1.17
+                  value: quay.io/file-integrity-operator/file-integrity-operator:0.1.18
+                image: quay.io/file-integrity-operator/file-integrity-operator:0.1.18
                 imagePullPolicy: Always
                 name: file-integrity-operator
                 resources:
@@ -119,6 +119,7 @@ spec:
               volumes:
               - name: serving-cert
                 secret:
+                  optional: true
                   secretName: file-integrity-operator-serving-cert
       permissions:
       - rules:
@@ -261,4 +262,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/openshift/file-integrity-operator
-  version: 0.1.17
+  version: 0.1.18


### PR DESCRIPTION
## [0.1.18] - 2021-08-20
### Changes
- Optimize per-node reinit calls
- Handle metrics service during operator start
- Bug 1862022: Per-node reinit during update
- Update Dockerfile.ci goland and base image
- Use fedora-minimal:34 base image