### PR TITLE
minor: adapt prometheusrule to only alert on currently existing nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ spec:
         description: Node {{ $labels.node }} has an an integrity check status of Failed for
           more than 1 second.
         summary: Node {{ $labels.node }} has a file integrity failure
-      expr: file_integrity_operator_node_failed{node=~".+"} == 1
+      expr: file_integrity_operator_node_failed{node=~".+"} * on(node) kube_node_info > 0
       for: 1s
       labels:
         severity: warning

--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -250,7 +250,7 @@ func ensureMetricsServiceAndSecret(ctx context.Context, kClient *kubernetes.Clie
 func createIntegrityFailureAlert(ctx context.Context, client *monclientv1.MonitoringV1Client, namespace string) error {
 	rule := monitoring.Rule{
 		Alert: "NodeHasIntegrityFailure",
-		Expr:  intstr.FromString(`file_integrity_operator_node_failed{node=~".+"} == 1`),
+		Expr:  intstr.FromString(`file_integrity_operator_node_failed{node=~".+"} * on(node) kube_node_info > 0`),
 		For:   "1s",
 		Labels: map[string]string{
 			"severity": "warning",


### PR DESCRIPTION
background: on a cluster with frequently changing nodes there's a lot of alert noise generated because of lingering fileintegritynodestatuses belonging to nodes that don't exist anymore.
Maybe a better approach would be to delete the fileintegritynodestatus here: https://github.com/openshift/file-integrity-operator/blob/a61147841dccfb5719f042476f144270a0d2551d/pkg/controller/node/node_controller.go#L101 (unfortunately that exceeds my read-only Golang capabilities)