### PR TITLE
Use `oc apply` instead of `oc create` for namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,8 +282,8 @@ endif
 
 .PHONY: namespace
 namespace:
-	@echo "Creating '$(NAMESPACE)' namespace/project"
-	@oc create -f deploy/ns.yaml || true
+	@echo "Ensuring '$(NAMESPACE)' namespace/project"
+	@oc apply -f deploy/ns.yaml
 
 .PHONY: deploy
 deploy: namespace deploy-crds ## Deploy the operator from the manifests in the deploy/ directory


### PR DESCRIPTION
This simplifies the namespace creation target by using apply; with this,
we'll no longer see error messages when the namespace already exists.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>