### PR TITLE
Release v0.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.21] - 2021-10-26
+### Changes
+- Use `oc apply` instead of `oc create` for namespace
+- Handle IO error in init database more leniently
+
 ## [0.1.20] - 2021-10-05
 ### Changes
 - Makefile: Make image bundle depend on $TAG

--- a/deploy/olm-catalog/file-integrity-operator/manifests/file-integrity-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/file-integrity-operator/manifests/file-integrity-operator.clusterserviceversion.yaml
@@ -19,12 +19,12 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=0.1.6 <0.1.20'
+    olm.skipRange: '>=0.1.6 <0.1.21'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-file-integrity
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/openshift/file-integrity-operator
-  name: file-integrity-operator.v0.1.20
+  name: file-integrity-operator.v0.1.21
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -109,8 +109,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: file-integrity-operator
                 - name: RELATED_IMAGE_OPERATOR
-                  value: quay.io/file-integrity-operator/file-integrity-operator:0.1.20
-                image: quay.io/file-integrity-operator/file-integrity-operator:0.1.20
+                  value: quay.io/file-integrity-operator/file-integrity-operator:0.1.21
+                image: quay.io/file-integrity-operator/file-integrity-operator:0.1.21
                 imagePullPolicy: Always
                 name: file-integrity-operator
                 resources:
@@ -273,4 +273,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/openshift/file-integrity-operator
-  version: 0.1.20
+  version: 0.1.21


### PR DESCRIPTION
## [0.1.21] - 2021-10-26
### Changes
- Use `oc apply` instead of `oc create` for namespace
- Handle IO error in init database more leniently