### PR TITLE
Bug 2033311: Move aide.reinit to /run

### DIFF
--- a/cmd/manager/daemon.go
+++ b/cmd/manager/daemon.go
@@ -37,8 +37,9 @@ import (
 )
 
 const (
-	defaultAideFileDir   = "/hostroot/etc/kubernetes"
-	defaultAideConfigDir = "/tmp"
+	defaultAideFileDir    = "/hostroot/etc/kubernetes"
+	defaultAideConfigDir  = "/tmp"
+	defaultAideRuntimeDir = "/hostroot/run"
 	// Files for checks and reading. We copy the AIDE output files to here.
 	aideReadDBFileName  = "aide.db.gz"
 	aideReadLogFileName = "aide.log"
@@ -74,6 +75,7 @@ type daemonConfig struct {
 	Local                     bool
 	Pprof                     bool
 	FileDir                   string
+	RunDir                    string
 	ConfigDir                 string
 }
 
@@ -184,6 +186,7 @@ func defineFlags(cmd *cobra.Command) {
 	cmd.Flags().String("lc-config-map-prefix", "", "Prefix for the configMap name, typically the podname.")
 	cmd.Flags().String("namespace", "", "Namespace")
 	cmd.Flags().String("aidefiledir", defaultAideFileDir, "The directory where the daemon will look for AIDE runtime files. Should only be changed when debugging.")
+	cmd.Flags().String("aideruntimedir", defaultAideRuntimeDir, "The directory where the daemon will look for AIDE temporary runtime files. Should only be changed when debugging.")
 	cmd.Flags().String("aideconfigdir", defaultAideConfigDir, "The directory where the daemon will look for the AIDE config. Should only be changed when debugging.")
 	cmd.Flags().Int64("lc-timeout", defaultTimeout, "How long to poll for the log and indicator files in seconds.")
 	cmd.Flags().Int64("interval", common.DefaultGracePeriod, "How often to recheck for AIDE results.")
@@ -199,6 +202,7 @@ func parseDaemonConfig(cmd *cobra.Command) *daemonConfig {
 	conf.FileIntegrityName = getValidStringArg(cmd, "owner")
 	conf.Namespace = getValidStringArg(cmd, "namespace")
 	conf.FileDir = getValidStringArg(cmd, "aidefiledir")
+	conf.RunDir = getValidStringArg(cmd, "aideruntimedir")
 	conf.ConfigDir = getValidStringArg(cmd, "aideconfigdir")
 	conf.LogCollectorNode = os.Getenv("NODE_NAME")
 	conf.LogCollectorConfigMapName = getConfigMapName(getValidStringArg(cmd, "lc-config-map-prefix"), conf.LogCollectorNode)

--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -3,7 +3,7 @@ package fileintegrity
 const aideLogPath = "/hostroot/etc/kubernetes/aide.log"
 
 var aideReinitContainerScript = `#!/bin/sh
-    touch /hostroot/etc/kubernetes/aide.reinit
+    touch /hostroot/run/aide.reinit
 `
 
 var aidePauseContainerScript = `#!/bin/sh


### PR DESCRIPTION
Related to https://github.com/ostreedev/ostree/pull/2453, this moves the
aide.reinit file to /run (under hostroot) to avoid a possible race condition on
node shutdown.

https://github.com/openshift/file-integrity-operator/issues/211

@jhrozek @JAORMX 