### PR TITLE
Bug 2049206: Re-create AIDE configMaps with missing owner

### DIFF
--- a/pkg/controller/fileintegrity/cm_to_fi_mapper.go
+++ b/pkg/controller/fileintegrity/cm_to_fi_mapper.go
@@ -23,11 +23,12 @@ func (s *fileIntegrityMapper) Map(obj handler.MapObject) []reconcile.Request {
 	}
 
 	for _, fi := range fiList.Items {
-		if fi.Spec.Config.Name != obj.Meta.GetName() {
+		// Check for the desired user config, or the default (in the upgrade case).
+		if fi.Spec.Config.Name != obj.Meta.GetName() && fi.Name != obj.Meta.GetName() {
 			continue
 		}
 
-		if fi.Spec.Config.Namespace != obj.Meta.GetNamespace() {
+		if fi.Spec.Config.Namespace != obj.Meta.GetNamespace() && fi.Namespace != obj.Meta.GetNamespace() {
 			continue
 		}
 

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -143,12 +143,16 @@ func (r *ReconcileFileIntegrity) handleDefaultConfigMaps(logger logr.Logger, f *
 			return nil, scriptsUpdated, err
 		}
 		return nil, scriptsUpdated, nil
-	} else if _, ok := confCm.Data[common.DefaultConfDataKey]; !ok {
-		// we had the configMap but its data was missing for some reason, so restore it.
-		if err := r.client.Update(context.TODO(), defaultAIDEConfigMap(f.Name)); err != nil {
-			return nil, scriptsUpdated, err
+	} else {
+		_, hasData := confCm.Data[common.DefaultConfDataKey]
+		_, hasOwner := confCm.Labels[common.IntegrityOwnerLabelKey]
+		if !hasData || !hasOwner {
+			// we had the configMap but its data or owner label was missing, so restore it.
+			if err := r.client.Update(context.TODO(), defaultAIDEConfigMap(f.Name)); err != nil {
+				return nil, scriptsUpdated, err
+			}
+			return nil, scriptsUpdated, nil
 		}
-		return nil, scriptsUpdated, nil
 	}
 
 	return confCm, scriptsUpdated, nil


### PR DESCRIPTION
When upgrading from much older versions, the AIDE configMaps that correspond to
FileIntegrity instances were left without an owner label, and this broke
re-inits. Fix this by re-creating the configMaps if they are found without the
owner label.