### PR TITLE
Break apart the make target for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,13 +378,19 @@ git-release: package-version-to-tag changelog
 	git checkout -b "release-v$(TAG)"
 	git add "deploy/olm-catalog/file-integrity-operator/"
 	git add "CHANGELOG.md"
+
+.PHONY: prepare-release
+prepare-release: release-tag-image bundle git-release
+
+.PHONY: push-release ## Do an official release (Requires permissions)
+push-release: package-version-to-tag
 	git commit -m "Release v$(TAG)"
 	git tag "v$(TAG)"
 	git push origin "v$(TAG)"
 	git push origin "release-v$(TAG)"
 
-.PHONY: release
-release: release-tag-image bundle push push-index undo-deploy-tag-image git-release ## Do an official release (Requires permissions)
+.PHONY: release-images
+release-images: package-version-to-tag push push-index undo-deploy-tag-image
 	# This will ensure that we also push to the latest tag
 	$(MAKE) push TAG=latest
 

--- a/README.md
+++ b/README.md
@@ -341,3 +341,38 @@ spec:
 ```
 
 The severity label and `for` may be adjusted depending on taste.
+
+## Contributor Guide
+
+This guide provides useful information for contributors.
+
+### Proposing Releases
+
+The release process is separated into three phases, with dedicated `make`
+targets. All targets require that you supply the `OPERATOR_VERSION` prior to
+running `make`, which should be a semantic version formatted string (e.g.,
+`OPERATOR_VERSION=0.1.49`).
+
+#### Preparing the Release
+
+The first phase of the release process is preparing the release locally. You
+can do this by running the `make prepare-release` target. All changes are
+staged locally. This is intentional so that you have the opportunity to
+review the changes before proposing the release in the next step.
+
+#### Proposing the Release
+
+The second phase of the release is to push the release to a dedicated branch
+against the origin repository. You can perform this step using the `make
+push-release` target.
+
+Please note, this step makes changes to the upstream repository, so it is
+imperative that you review the changes you're committing prior to this step.
+This steps also requires that you have necessary permissions on the repository.
+
+#### Releasing Images
+
+The third and final step of the release is to build new images and push them to
+an offical image registry. You can build new images and push using `make
+release-images`. Note that this operation also requires you have proper
+permissions on the remote registry.


### PR DESCRIPTION
Previously, we used a single makefile target for doing a release (e.g.,
`make release`). This works well, but we started using a multi-step
process in the compliance-operator [0] that prepares the release and
gives the person proposing the release an opportunity to review the
release details before pushing them to the repository. This helps catch
issues before we change details of the upstream repository that could
impact how the code is consumed.

[0] https://github.com/openshift/compliance-operator/blob/master/doc/contributor.md#proposing-releases