### PR TITLE
Bug 2072058: Use correct data keys for script configMaps

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -40,6 +40,7 @@ const (
 	DaemonSetPrefix                    = "aide"
 	DefaultConfDataKey                 = "aide.conf"
 	AideScriptKey                      = "aide.sh"
+	AidePauseScriptKey                 = "pause.sh"
 	OperatorServiceAccountName         = "file-integrity-operator"
 	DaemonServiceAccountName           = "file-integrity-daemon"
 	ReinitDaemonSetPrefix              = "aide-ini"

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -593,17 +593,17 @@ func aidePauseScript() *corev1.ConfigMap {
 			Namespace: common.FileIntegrityNamespace,
 		},
 		Data: map[string]string{
-			"pause.sh": aidePauseContainerScript,
+			common.AidePauseScriptKey: aidePauseContainerScript,
 		},
 	}
 }
 
 func dataMatchesReinitScript(cm *corev1.ConfigMap) bool {
-	return configMapKeyDataMatches(cm, aideReinitScript(), common.DefaultConfDataKey)
+	return configMapKeyDataMatches(cm, aideReinitScript(), common.AideScriptKey)
 }
 
 func dataMatchesPauseScript(cm *corev1.ConfigMap) bool {
-	return configMapKeyDataMatches(cm, aidePauseScript(), common.DefaultConfDataKey)
+	return configMapKeyDataMatches(cm, aidePauseScript(), common.AidePauseScriptKey)
 }
 
 func configMapKeyDataMatches(cm1, cm2 *corev1.ConfigMap, key string) bool {


### PR DESCRIPTION
Previously when enforcing the default configMap script contents, we compared
the wrong data keys. This led to the aide-reinit script not being updated
properly on an operator upgrade.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2072058

@openshift/infrastructure-security-compliance 