### PR TITLE
Use fedora-minimal:latest for container builds

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -10,7 +10,7 @@ COPY . .
 RUN make operator-bin
 
 # Step two: containerize file-integrity-operator and AIDE together
-FROM registry.fedoraproject.org/fedora-minimal:34
+FROM registry.fedoraproject.org/fedora-minimal:latest
 RUN microdnf -y install aide golang && microdnf clean all
 
 ENV OPERATOR=/usr/local/bin/file-integrity-operator \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN make operator-bin
 
 # Step two: containerize file-integrity-operator and AIDE together
-FROM registry.fedoraproject.org/fedora-minimal:34
+FROM registry.fedoraproject.org/fedora-minimal:latest
 RUN microdnf -y install aide golang && microdnf clean all
 
 ENV OPERATOR=/usr/local/bin/file-integrity-operator \


### PR DESCRIPTION
Before we were using fedora-minimal:34, which is susceptible to multiple
CVEs that were picked up in vulnerability scans:

  CVE-2021-28363
  CVE-2021-3572
  PVE-2021-42218

All of these are related to pip, Python's package manager. Let's use a
newer version of fedora to pick up a newer version of pip.