### PR TITLE
Allow running under OLM's AllNamespaces install mode

### DIFF
--- a/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - Integrity

--- a/pkg/common/var.go
+++ b/pkg/common/var.go
@@ -29,7 +29,9 @@ func GetOperatorNamespace() (string, error) {
 	return ns, nil
 }
 
-// GetWatchNamespace returns the Namespace the operator should be watching for changes
+// GetWatchNamespace returns the Namespace the operator should be watching for changes. Eventually the watch namespace
+// will not be used when OLM begins to support only the AllNamespaces install type. To support AllNamespaces initially,
+// GetWatchNamespace will return the operator namespace if WATCH_NAMESPACE is empty.
 func GetWatchNamespace() (string, error) {
 	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
 	// which specifies the Namespace to watch.
@@ -39,6 +41,14 @@ func GetWatchNamespace() (string, error) {
 	ns, found := os.LookupEnv(watchNamespaceEnvVar)
 	if !found {
 		return "", fmt.Errorf("%s must be set", watchNamespaceEnvVar)
+	}
+
+	if ns == "" {
+		opns, err := GetOperatorNamespace()
+		if err != nil {
+			return "", err
+		}
+		ns = opns
 	}
 	return ns, nil
 }


### PR DESCRIPTION
This is related to the "de-scoping" changes that OLM will see. It means that eventually OLM will only install operators using the AllNamespaces installModeType, which sets WATCH_NAMESPACE to empty, and assumes that the operator will watch for objects in all namespaces. This PR enables AllNamespaces as a supported type, and forces to Own/SingleNamespace mode when running. 

Note, forcing the OwnNamespace mode might seem like a hack, but we can't safely fully de-scope (switch to watching all namespaces) until OLM is able to restrict an operator to a single namespace through its new API (tentatively called "FeatureBinding"). Also, fully-descoping is only critical for operators that have dependencies, or depended on by operators with multiple installModes, or singleton operators that are multi-tenant aware.

Ref: https://issues.redhat.com/browse/OLM-1579
Ref: https://issues.redhat.com/browse/CMP-1355