### PR TITLE
tests: Use busybox from quay to work around dockerhub's rate limit

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -502,7 +502,7 @@ func privPodOnNode(namespace, name, nodeName, command string) *corev1.Pod {
 						RunAsUser:  &runAs,
 					},
 					Name:    name,
-					Image:   "busybox",
+					Image:   "quay.io/prometheus/busybox",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", command},
 					VolumeMounts: []corev1.VolumeMount{
@@ -567,7 +567,7 @@ func privCommandDaemonset(namespace, name, command string) *appsv1.DaemonSet {
 								RunAsUser:  &runAs,
 							},
 							Name:    name,
-							Image:   "busybox",
+							Image:   "quay.io/prometheus/busybox",
 							Command: []string{"/bin/sh"},
 							Args:    []string{"-c", command},
 							VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
When running the e2e tests repeatedly, it's possible to hit github's
rate limit. Using an image from quay.io should work around the issue.

Since the prometheus project seems to be actively updating their busybox
image, let's use that one instead of importing and then not maintaining
our own.
