### PR TITLE
config/ns: Add pod-security.kubernetes.io labels to the namespace

### DIFF
--- a/config/ns/ns.yaml
+++ b/config/ns/ns.yaml
@@ -3,4 +3,7 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: openshift-file-integrity


### PR DESCRIPTION
This prevents warnings on OCP 4.11+
