### PR TITLE
bug 2101393: operator: Set namespace label for alert

### DIFF
--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -268,7 +268,8 @@ func createIntegrityFailureAlert(ctx context.Context, client *monclientv1.Monito
 		Expr:  intstr.FromString(`file_integrity_operator_node_failed{node=~".+"} * on(node) kube_node_info > 0`),
 		For:   "1s",
 		Labels: map[string]string{
-			"severity": "warning",
+			"severity":  "warning",
+			"namespace": namespace,
 		},
 		Annotations: map[string]string{
 			"summary":     "Node {{ $labels.node }} has a file integrity failure",


### PR DESCRIPTION
According to style guide
https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#style-guide
an alert should set namespace label to identify which component is raising
the alert however NodeHasIntegrityFailure is not setting namespace label:
https://github.com/openshift/file-integrity-operator/blob/master/cmd/manager/operator.go#L266

rhbz: #2101393
