### PR TITLE
Use an absolute git reference for the upstream repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@ endif
 
 # Git options.
 GIT_OPTS?=
-# Set this to the remote used for the upstream repo (for release)
-GIT_REMOTE?=origin
+# Set this to the remote used for the upstream repo (for release). Use an
+# absolute reference since we don't know if origin is the contributor's fork or
+# if it's the upstream repository.
+GIT_REMOTE?=git@github-redhat:openshift/file-integrity-operator.git
 
 # Image tag to use. Set this if you want to use a specific tag for building
 # or your e2e tests.


### PR DESCRIPTION
Before, we assumed `origin` always pointed to the upstream repository
for the operator (openshift/file-integrity-operator). This might not be
the case if someone sets `origin` to their own fork and uses `upstream`
to point to openshift/file-integrity-operator.

Either way, we can generalize the git push commands to use an
absolute-like reference for the remote.

Fixes #246