### PR TITLE
Fix bad remote URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GIT_OPTS?=
 # Set this to the remote used for the upstream repo (for release). Use an
 # absolute reference since we don't know if origin is the contributor's fork or
 # if it's the upstream repository.
-GIT_REMOTE?=git@github-redhat:openshift/file-integrity-operator.git
+GIT_REMOTE?=git@github.com:openshift/file-integrity-operator.git
 
 # Image tag to use. Set this if you want to use a specific tag for building
 # or your e2e tests.


### PR DESCRIPTION
This was a bad copy/pasta from my SSH settings. Fix it so that the
remote host is correct and uses github.com.