### PR TITLE
Bug 2104897: Use ClusterRole and local RoleBinding for daemon permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,6 +435,7 @@ prep-e2e: kustomize
 	mkdir -p $(TEST_SETUP_DIR)
 	$(KUSTOMIZE) build config/e2e > $(TEST_DEPLOY)
 	$(KUSTOMIZE) build config/crd > $(TEST_CRD)
+	cat config/rbac/daemon_rolebinding.yaml >> $(TEST_DEPLOY)
 
 ifdef IMAGE_FROM_CI
 e2e-set-image: kustomize

--- a/bundle/manifests/file-integrity-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/file-integrity-daemon_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: file-integrity-daemon

--- a/bundle/manifests/file-integrity-daemon_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/file-integrity-daemon_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -5,9 +5,8 @@ metadata:
   name: file-integrity-daemon
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: file-integrity-daemon
 subjects:
 - kind: ServiceAccount
   name: file-integrity-daemon
-  namespace: openshift-file-integrity

--- a/config/rbac/daemon_role.yaml
+++ b/config/rbac/daemon_role.yaml
@@ -1,7 +1,7 @@
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: file-integrity-daemon
 rules:

--- a/config/rbac/daemon_rolebinding.yaml
+++ b/config/rbac/daemon_rolebinding.yaml
@@ -1,3 +1,6 @@
+# Daemon rolebinding is not applied to bundle/manifests by bundle generation on purpose, instead we should copy by hand
+#  to bundle/manifests. Reason being to avoid adding a namespace to subjects.
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -6,6 +9,6 @@ subjects:
   - kind: ServiceAccount
     name: file-integrity-daemon
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: file-integrity-daemon
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
 - operator_clusterrole.yaml
 - operator_clusterrolebinding.yaml
 - daemon_role.yaml
-- daemon_rolebinding.yaml
 - prometheus_rolebinding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml


### PR DESCRIPTION
Fixes permissions for an OLM install when installing into a namespace other
than openshift-file-integrity.

- Remove the daemon RoleBinding from kustomize under config/rbac. This avoids
  adding an openshift-file-integrity namespace to the subject SA during bundle
  creation.
- Change the daemon Role to a ClusterRole

ref: https://bugzilla.redhat.com/show_bug.cgi?id=2104897