### PR TITLE
Makefile: Fix build dir recipe override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,10 +233,6 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
-
-$(BUILD_DIR):
-	mkdir -p $(BUILD_DIR)
-
 # Build a go module from a single argument, which is a file path to a go
 # module. The module is built and output to the build/ directory.
 define go-build


### PR DESCRIPTION
Since the default build directory is "build", the $(BUILD_DIR) target
triggered an override warning.

  Makefile:310: warning: overriding recipe for target 'build'                                                                                                                                                                            
  Makefile:238: warning: ignoring old recipe for target 'build'

This removes the $(BUILD_DIR) target since ./build is part of the git
tree and should not need to be created prior to other targets.