### PR TITLE
Bug 2108475: Change daemon RBAC back to Role

### DIFF
--- a/bundle/manifests/file-integrity-daemon_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/file-integrity-daemon_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   creationTimestamp: null
   name: file-integrity-daemon

--- a/bundle/manifests/file-integrity-daemon_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/file-integrity-daemon_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name: file-integrity-daemon
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: file-integrity-daemon
 subjects:
 - kind: ServiceAccount

--- a/config/rbac-daemon/daemon_rolebinding.yaml
+++ b/config/rbac-daemon/daemon_rolebinding.yaml
@@ -9,6 +9,6 @@ subjects:
   - kind: ServiceAccount
     name: file-integrity-daemon
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: file-integrity-daemon
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/daemon_role.yaml
+++ b/config/rbac/daemon_role.yaml
@@ -1,7 +1,7 @@
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: file-integrity-daemon
 rules:


### PR DESCRIPTION
Moving the daemon Role to a ClusterRole as part of the fix for 2104897
was unnecessary and broke OLM upgrades.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2108475