### PR TITLE
Ensure we build latest images when we release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,7 +470,9 @@ push-release: package-version-to-tag ## Do an official release (Requires permiss
 .PHONY: release-images
 release-images: package-version-to-tag push catalog
 	# This will ensure that we also push to the latest tag
+	$(MAKE) images TAG=latest
 	$(MAKE) push TAG=latest
+	$(MAKE) catalog-image TAG=latest
 	$(MAKE) catalog-push TAG=latest
 
 .PHONY: changelog


### PR DESCRIPTION
We have a couple of final steps in the `release-images` target that
tags the latest images with the most recent release. But, to do this, we
need to build the images and tag them locally before we push them to
Quay. Not doing this will result in failures to release the images
because podman can't find the tag locally.

This commit fixes the issue by adding steps to build the images locally
and then tag them with latest before pushing to Quay.