### PR TITLE
e2e: Allow running against an existing deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,14 +197,28 @@ LAST SEEN   TYPE      REASON                OBJECT                              
 40m         Warning   NodeIntegrityStatus   fileintegrity/example-fileintegrity   node ip-10-0-152-92.ec2.internal has changed! a:3,c:1,r:0 log:openshift-file-integrity/aide-ds-example-fileintegrity-ip-10-0-152-92.ec2.internal-failed
 ```
 
-### Local testing
+## Testing
+### Unit
+```
+$ make test-unit
+```
+
+### Local
 ```
 $ make run
 ```
 
-### Running the end-to-end suite
+### End-to-end
 ```
 $ make e2e
+```
+
+Running the e2e suite normally handles the operator deployment for each test case. The e2e suite can also be run against an existing deployment with the `TEST_BUNDLE_INSTALL` variable (set to `1` or `true`). The following example builds development images including the bundle and catalog, deploys them to a running cluster, and executes the e2e suite against the deployment.
+```
+$ export IMAGE_REPO=myrepo
+$ export TAG=testing
+$ make images && make push && make catalog && make catalog-deploy
+$ TEST_BUNDLE_INSTALL=1 TEST_WATCH_NAMESPACE=openshift-file-integrity TEST_OPERATOR_NAMESPACE=openshift-file-integrity make e2e
 ```
 
 ## Overriding the AIDE configuration

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -27,6 +27,9 @@ func TestFileIntegrityLogAndReinitDatabase(t *testing.T) {
 		if err := cleanNodes(f, namespace); err != nil {
 			t.Fatal(err)
 		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
+			t.Fatal(err)
+		}
 	}()
 	defer logContainerOutput(t, f, namespace, testName)
 
@@ -142,6 +145,9 @@ func TestFileIntegrityLegacyReinitCleanup(t *testing.T) {
 		if err := cleanNodes(f, namespace); err != nil {
 			t.Fatal(err)
 		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
+			t.Fatal(err)
+		}
 	}()
 	defer logContainerOutput(t, f, namespace, testName)
 
@@ -202,6 +208,9 @@ func TestFileIntegrityPruneBackup(t *testing.T) {
 	defer testctx.Cleanup()
 	defer func() {
 		if err := cleanNodes(f, namespace); err != nil {
+			t.Fatal(err)
+		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -287,6 +296,9 @@ func TestFileIntegrityConfigurationRevert(t *testing.T) {
 	defer testctx.Cleanup()
 	defer func() {
 		if err := cleanNodes(f, namespace); err != nil {
+			t.Fatal(err)
+		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -403,6 +415,9 @@ func TestFileIntegrityConfigurationStatus(t *testing.T) {
 		if err := cleanNodes(f, namespace); err != nil {
 			t.Fatal(err)
 		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
+			t.Fatal(err)
+		}
 	}()
 	defer logContainerOutput(t, f, namespace, testName)
 
@@ -464,6 +479,9 @@ func TestFileIntegrityConfigurationIgnoreMissing(t *testing.T) {
 		if err := cleanNodes(f, namespace); err != nil {
 			t.Fatal(err)
 		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
+			t.Fatal(err)
+		}
 	}()
 	defer logContainerOutput(t, f, namespace, testName)
 
@@ -499,6 +517,9 @@ func TestFileIntegrityConfigMapOwnerUpdate(t *testing.T) {
 		if err := cleanNodes(f, namespace); err != nil {
 			t.Fatal(err)
 		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
+			t.Fatal(err)
+		}
 	}()
 	defer logContainerOutput(t, f, namespace, testName)
 
@@ -524,6 +545,9 @@ func TestFileIntegrityChangeGracePeriod(t *testing.T) {
 	defer testctx.Cleanup()
 	defer func() {
 		if err := cleanNodes(f, namespace); err != nil {
+			t.Fatal(err)
+		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -599,6 +623,9 @@ func TestFileIntegrityChangeDebug(t *testing.T) {
 		if err := cleanNodes(f, namespace); err != nil {
 			t.Fatal(err)
 		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
+			t.Fatal(err)
+		}
 	}()
 	defer logContainerOutput(t, f, namespace, testName)
 
@@ -672,6 +699,9 @@ func TestFileIntegrityBadConfig(t *testing.T) {
 		if err := cleanNodes(f, namespace); err != nil {
 			t.Fatal(err)
 		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
+			t.Fatal(err)
+		}
 	}()
 	defer logContainerOutput(t, f, namespace, testName)
 
@@ -703,6 +733,9 @@ func TestFileIntegrityTolerations(t *testing.T) {
 		if err := cleanNodes(f, namespace); err != nil {
 			t.Fatal(err)
 		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
+			t.Fatal(err)
+		}
 	}()
 	defer logContainerOutput(t, f, namespace, testIntegrityNamePrefix+"-tolerations")
 
@@ -728,6 +761,9 @@ func TestFileIntegrityLogCompress(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := cleanAddedFilesOnNodes(f, namespace); err != nil {
+			t.Fatal(err)
+		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -800,6 +836,9 @@ func TestFileIntegrityAcceptsExpectedChange(t *testing.T) {
 	defer testctx.Cleanup()
 	defer func() {
 		if err := cleanNodes(f, namespace); err != nil {
+			t.Fatal(err)
+		}
+		if err := resetBundleTestMetrics(f, namespace); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -99,6 +99,7 @@ const (
 
 	TestOperatorNamespaceEnv = "TEST_OPERATOR_NAMESPACE"
 	TestWatchNamespaceEnv    = "TEST_WATCH_NAMESPACE"
+	TestBundleInstallEnv     = "TEST_BUNDLE_INSTALL"
 )
 
 func (opts *frameworkOpts) addToFlagSet(flagset *flag.FlagSet) {


### PR DESCRIPTION
- Add `TEST_BUNDLE_INSTALL` env variable that makes the e2e suite skip initialization of the cluster and operator resources for each test case. This allows running the e2e suite against an existing deployment in a single namespace (such as an OLM install) when used together with `TEST_WATCH_NAMESPACE` and `TEST_OPERATOR_NAMESPACE`.
- Add a test case cleanup step to kill the operator pod when `TEST_BUNDLE_INSTALL` is used. This resets the metrics counter for subsequent tests.

Test with:
```
$ make catalog-deploy
$ TEST_BUNDLE_INSTALL=1 TEST_WATCH_NAMESPACE=openshift-file-integrity TEST_OPERATOR_NAMESPACE=openshift-file-integrity make e2e
```
ref: https://github.com/openshift/release/pull/30613
fixes: https://github.com/openshift/file-integrity-operator/issues/269