### PR TITLE
Generate bundle

### DIFF
--- a/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
@@ -274,6 +274,8 @@ spec:
           - prometheusrules
           verbs:
           - create
+          - get
+          - update
         - apiGroups:
           - monitoring.coreos.com
           resources:


### PR DESCRIPTION
This is to include the permission updates from be830f7 into the CSV. Normally we do this during the release; doing it before that makes sure these permissions are included for the bundle-ci jobs. 

ref: https://github.com/openshift/release/pull/31464
@rhmdnd @jhrozek PTAL. We'll override the bundle jobs on this PR as well.