### PR TITLE
Updates AIDE Daemonset default tolerations to account for ROSA infra nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ status:
 ```
 In the `spec`:
 * **nodeSelector**: Selector for nodes to schedule the scan instances on.
-* **tolerations**: Specify tolerations to schedule on nodes with custom taints. When not specified, a default toleration allowing running on master nodes is applied.
+* **tolerations**: Specify tolerations to schedule on nodes with custom taints. When not specified, a default toleration allowing running on master and infra nodes is applied.
 * **config**: Point to a ConfigMap containing an AIDE configuration to use instead of the CoreOS optimized default. See "Applying an AIDE config" below.
 * **config.gracePeriod**: The number of seconds to pause in between AIDE integrity checks. Frequent AIDE checks on a node may be resource intensive, so it can be useful to specify a longer interval. Defaults to 900 (15 mins).
 * **config.maxBackups**: The maximum number of AIDE database and log backups (leftover from the re-init process) to keep on a node. Older backups beyond this number are automatically pruned by the daemon. Defaults to 5.

--- a/config/crd/bases/fileintegrity.openshift.io_fileintegrities.yaml
+++ b/config/crd/bases/fileintegrity.openshift.io_fileintegrities.yaml
@@ -75,8 +75,11 @@ spec:
                 - effect: NoSchedule
                   key: node-role.kubernetes.io/master
                   operator: Exists
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
                 description: Specifies tolerations for custom taints. Defaults to
-                  allowing scheduling on master nodes.
+                  allowing scheduling on master and infra nodes.
                 items:
                   description: The pod this Toleration is attached to tolerates any
                     taint that matches the triple <key,value,effect> using the matching

--- a/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
+++ b/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
@@ -46,8 +46,8 @@ type FileIntegritySpec struct {
 	NodeSelector map[string]string   `json:"nodeSelector,omitempty"`
 	Config       FileIntegrityConfig `json:"config"`
 	Debug        bool                `json:"debug,omitempty"`
-	// Specifies tolerations for custom taints. Defaults to allowing scheduling on master nodes.
-	// +kubebuilder:default={{key: "node-role.kubernetes.io/master", operator: "Exists", effect: "NoSchedule"}}
+	// Specifies tolerations for custom taints. Defaults to allowing scheduling on master and infra nodes.
+	// +kubebuilder:default={{key: "node-role.kubernetes.io/master", operator: "Exists", effect: "NoSchedule"},{key: "node-role.kubernetes.io/infra", operator: "Exists", effect: "NoSchedule"}}
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 


### PR DESCRIPTION
This PR updates the default daemonset toleration to also include infra nodes.

With FedRAMP clusters using ROSA exclusively, we noticed that the AIDE daemonset pods were not spinning up on infra nodes. Looks like the default setting for tolerations is only configured for master nodes, but ROSA also has a similar taint configured on infra nodes as well. 

```shell
$ oc describe nodes -l node-role.kubernetes.io/infra | grep Taint
Taints:             node-role.kubernetes.io/infra:NoSchedule
Taints:             node-role.kubernetes.io/infra:NoSchedule
```
We've fixed our issue by adding it to the `FileIntegrity` CR we deploy via OLM but I thought it might be good to update the default for other customers who may use FIO outside of FedRAMP. Chances are if a customer is leveraging FIO for their cluster, they are trying to meet some form of compliance requirement and will need all nodes scanned. The default should account for that in case they do not catch the config options available in the `FileIntegrity` CR