### PR TITLE
Ignore generated setup files for end-to-end tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/operator-sdk
 build/opm
 bundle_*
 _testdata
+tests/_setup


### PR DESCRIPTION
The operator-sdk generates files for end-to-end testing and puts them in
tests/_setup. We don't need to track these in the repository, so let's
ignore them.
