### PR TITLE
make: Workaround to make the upstram catalog usable on 4.12+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ bundle-image: bundle ## Build the bundle image.
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-image
 catalog-image: opm ## Build a catalog image.
-	$(OPM) index add --container-tool $(RUNTIME) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --binary-image registry.redhat.io/openshift4/ose-operator-registry:v4.11 --container-tool $(RUNTIME) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 .PHONY: catalog
 catalog: catalog-image catalog-push ## Build and push a catalog image.


### PR DESCRIPTION
NOTE: I'm not sure we should merge this PR. I'm mostly posting it up for
discussion. We could as well convert to a file based catalog:
```
opm migrate <registry_image> <fbc_directory>
opm generate dockerfile <fbc_directory> \
  --binary-image \
    registry.redhat.io/openshift4/ose-operator-registry:v4.11
```
or just create the file-based catalog from scratch. This PR might be useful
as a workaround though.

Implements the workaround found in:
    https://access.redhat.com/articles/6977554

This makes the FIO catalog usable on 4.12+. Note that fetching the
`registry.redhat.io/openshift4/ose-operator-registry:v4.11` image
requires authentication.
