### PR TITLE
Use go-install to fetch kustomize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Internal Changes
 
+- Update `make kustomize` to use `go install` for installing kustomize v4. This
+  is [necessary](https://github.com/openshift/file-integrity-operator/issues/287)
+  for installing kustomize using golang 1.18.
+
 ## [0.1.30] - 2022-07-25
 
 ### Fixes

--- a/Makefile
+++ b/Makefile
@@ -208,18 +208,18 @@ controller-gen: ## Build controller-gen from what's in vendor.
 
 KUSTOMIZE = $(shell pwd)/build/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-install-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
+define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/build go get $(2) ;\
+echo "Installing $(2)" ;\
+GOBIN=$(PROJECT_DIR)/build GOFLAGS=-mod=mod go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
This commit ensures we can install kustomize using golang 1.18 by using
v4 and using `go install`.

We needed to do something similar for other operators.

https://github.com/ComplianceAsCode/compliance-operator/issues/145

Fixes #287
