### PR TITLE
Fix make release-images to properly tag `latest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
+- Modify the release process to ensure the most recent version is tagged with
+  the `latest` tag for the upstream
+  [operator](https://quay.io/repository/file-integrity-operator/file-integrity-operator),
+  [catalog](https://quay.io/repository/file-integrity-operator/file-integrity-operator-catalog),
+  and
+  [bundle](https://quay.io/repository/file-integrity-operator/file-integrity-operator-bundle)
+  repositories available through quay.io.
+
 ### Internal Changes
 
 - Update `make kustomize` to use `go install` for installing kustomize v4. This

--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,13 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # openshift.io/file-integrity-operator-bundle:$VERSION and openshift.io/file-integrity-operator-catalog:$VERSION.
 IMAGE_TAG_BASE=$(IMAGE_REPO)/$(APP_NAME)
+OPERATOR_IMAGE?=$(IMAGE_TAG_BASE):$(TAG)
+
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(TAG)
+BUNDLE_TAG_BASE?=$(IMAGE_TAG_BASE)-bundle
+BUNDLE_IMG?=$(BUNDLE_TAG_BASE):$(TAG)
 
 # Includes additional service accounts into the bundle CSV.
 BUNDLE_SA_OPTS ?= --extra-service-accounts file-integrity-daemon
@@ -124,7 +127,8 @@ endif
 BUNDLE_IMGS ?= $(BUNDLE_IMG)
 
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(TAG)
+CATALOG_TAG_BASE?=$(IMAGE_TAG_BASE)-catalog
+CATALOG_IMG?=$(CATALOG_TAG_BASE):$(TAG)
 
 # Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
 ifneq ($(origin CATALOG_BASE_IMG), undefined)
@@ -478,6 +482,9 @@ push-release: package-version-to-tag ## Do an official release (Requires permiss
 
 .PHONY: release-images
 release-images: package-version-to-tag push catalog
+	$(RUNTIME) image tag $(OPERATOR_IMAGE) $(IMAGE_TAG_BASE):latest
+	$(RUNTIME) image tag $(BUNDLE_IMG) $(BUNDLE_TAG_BASE):latest
+	$(RUNTIME) image tag $(CATALOG_IMG) $(CATALOG_TAG_BASE):latest
 	# This will ensure that we also push to the latest tag
 	$(MAKE) push TAG=latest
 	$(MAKE) catalog-push TAG=latest


### PR DESCRIPTION
Previously, we'd only tag the latest version of the operator we're
releasing in the upstream images available through
quay.io/file-integrity-operator.

In addition to the version tag (e.g., 0.1.31), we can also tag the
latest build with the `latest` tag, making it easier for users to deploy
the latest version of the upstream operator.
