### PR TITLE
Fix deployment on OCP 4.6

### DIFF
--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -250,6 +250,14 @@ func ensureMetricsServiceAndSecret(ctx context.Context, kClient *kubernetes.Clie
 		if !reflect.DeepEqual(curService.Spec, newService.Spec) {
 			serviceCopy := curService.DeepCopy()
 			serviceCopy.Spec = newService.Spec
+
+			// OCP-4.6 only - Retain ClusterIP from the current service in case we overwrite it when copying the updated
+			// service. Avoids "Error creating metrics service/secret","error":"Service \"metrics\" is invalid: spec.clusterIP:
+			// Invalid value: \"\": field is immutable","stacktrace"...
+			if len(serviceCopy.Spec.ClusterIP) == 0 {
+				serviceCopy.Spec.ClusterIP = curService.Spec.ClusterIP
+			}
+
 			updatedService, updateErr := kClient.CoreV1().Services(ns).Update(ctx, serviceCopy, metav1.UpdateOptions{})
 			if updateErr != nil {
 				return nil, updateErr


### PR DESCRIPTION
Check against changing the Service's clusterIP, and retain the existing value as OCP 4.6 does not tolerate that. Later versions just ignore the field.

(same fix as https://github.com/ComplianceAsCode/compliance-operator/commit/404483b5b1e0c5519da5ea89c6d68baecd2b1140)