### PR TITLE
[WIP]: DS: Don't run privileged

### DIFF
--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -746,7 +746,7 @@ func reinitAideDaemonset(reinitDaemonSetName string, fi *v1alpha1.FileIntegrity,
 }
 
 func aideDaemonset(dsName string, fi *v1alpha1.FileIntegrity, operatorImage string) *appsv1.DaemonSet {
-	priv := true
+	priv := false
 	runAs := int64(0)
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -779,6 +779,9 @@ func aideDaemonset(dsName string, fi *v1alpha1.FileIntegrity, operatorImage stri
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &priv,
 								RunAsUser:  &runAs,
+								SELinuxOptions: &corev1.SELinuxOptions{
+									Type: "spc_t",
+								},
 							},
 							Name:  "daemon",
 							Image: common.GetComponentImage(operatorImage, common.OPERATOR),


### PR DESCRIPTION
Submitting this as a WIP because the current patch only touches one DS,
not the reinit DS and I'm not 100% sure about the ramifications either.

I hacked this together when I was recording FIO using SPO and was wondering
if this was something upstream was interested in.

while `spc_t` is unconfined, running as non-privileged with `spc_t` might be
preferable to running privileged because:
 - we don't turn off seccomp or SELinux completely, unlike privileged
   containers
 - the workloads won't be raising flags on admission in case some
   environments restrict privileged containers.
