### PR TITLE
Ensure we update the ocp-0.1 branch when releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,6 +476,9 @@ push-release: package-version-to-tag ## Do an official release (Requires permiss
 	git tag "v$(TAG)"
 	git push $(GIT_OPTS) $(GIT_REMOTE) "v$(TAG)"
 	git push $(GIT_OPTS) $(GIT_REMOTE) "release-v$(TAG)"
+	git checkout ocp-0.1
+	git merge "release-v$(TAG)"
+	git push $(GIT_REMOTE) ocp-0.1
 
 .PHONY: release-images
 release-images: package-version-to-tag push catalog


### PR DESCRIPTION
Some downstream machinery depends on the ocp-0.1 branch. Let's make sure
we sync the branch with the latest release during the `push-release`
process.

This is consistent with how we maintain the `ocp-0.1` branch in the
Compliance Operator.
