### PR TITLE
Update OCP release branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,9 +476,9 @@ push-release: package-version-to-tag ## Do an official release (Requires permiss
 	git tag "v$(TAG)"
 	git push $(GIT_OPTS) $(GIT_REMOTE) "v$(TAG)"
 	git push $(GIT_OPTS) $(GIT_REMOTE) "release-v$(TAG)"
-	git checkout ocp-0.1
+	git checkout ocp-1.0
 	git merge "release-v$(TAG)"
-	git push $(GIT_REMOTE) ocp-0.1
+	git push $(GIT_REMOTE) ocp-1.0
 
 .PHONY: release-images
 release-images: package-version-to-tag push catalog


### PR DESCRIPTION
This commit needs to merge before we release a 1.0.0 release and ensures
the OpenShift release align with the appropriate upstream releases.
