### PR TITLE
Add initialDelay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - the upstream catalog image is now built using the
   [file format](https://olm.operatorframework.io/docs/reference/file-based-catalogs/)
   replacing the now deprecated SQLite format.
+- We added `initialDelay` option to FileIntegrity CRD to allow users to specify
+  the initial delay before the first scan is run. This is useful for
+  environments where the operator is deployed before cluster is fully ready.
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ In the `spec`:
 * **config**: Point to a ConfigMap containing an AIDE configuration to use instead of the CoreOS optimized default. See "Applying an AIDE config" below.
 * **config.gracePeriod**: The number of seconds to pause in between AIDE integrity checks. Frequent AIDE checks on a node may be resource intensive, so it can be useful to specify a longer interval. Defaults to 900 (15 mins).
 * **config.maxBackups**: The maximum number of AIDE database and log backups (leftover from the re-init process) to keep on a node. Older backups beyond this number are automatically pruned by the daemon. Defaults to 5.
+* **config.initialDelay**: An optional field. The number of seconds to wait before starting the first AIDE integrity check. Defaults to 0. 
 
 In the `status`:
 * **phase**: The running status of the `FileIntegrity` instance. Can be `Initializing`, `Pending`, or `Active`. `Initializing` is displayed if the FileIntegrity is currently initializing or re-initializing the AIDE database, `Pending` if the FileIntegrity deployment is still being created, and `Active` if the scans are active and ongoing. For node scan results, see the `FileIntegrityNodeStatus` objects explained below.

--- a/bundle/manifests/fileintegrity.openshift.io_fileintegrities.yaml
+++ b/bundle/manifests/fileintegrity.openshift.io_fileintegrities.yaml
@@ -42,6 +42,11 @@ spec:
                     default: 900
                     description: Time between individual aide scans
                     type: integer
+                  initialDelay:
+                    description: InitialDelaySeconds is the number of seconds to wait
+                      before the first scan. It is an optional field, and if not specified,
+                      the operator will default to 0
+                    type: integer
                   key:
                     description: The key that contains the actual AIDE configuration
                       in a configmap specified by Name and Namespace. Defaults to

--- a/config/crd/bases/fileintegrity.openshift.io_fileintegrities.yaml
+++ b/config/crd/bases/fileintegrity.openshift.io_fileintegrities.yaml
@@ -44,6 +44,11 @@ spec:
                     default: 900
                     description: Time between individual aide scans
                     type: integer
+                  initialDelay:
+                    description: InitialDelaySeconds is the number of seconds to wait
+                      before the first scan. It is an optional field, and if not specified,
+                      the operator will default to 0
+                    type: integer
                   key:
                     description: The key that contains the actual AIDE configuration
                       in a configmap specified by Name and Namespace. Defaults to

--- a/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
+++ b/pkg/apis/fileintegrity/v1alpha1/fileintegrity_types.go
@@ -66,6 +66,9 @@ type FileIntegrityConfig struct {
 	// Older backups beyond this number are automatically pruned by the daemon.
 	// +kubebuilder:default=5
 	MaxBackups int `json:"maxBackups,omitempty"`
+	// InitialDelaySeconds is the number of seconds to wait before the first scan.
+	// It is an optional field, and if not specified, the operator will default to 0
+	InitialDelay int `json:"initialDelay,omitempty"`
 }
 
 // FileIntegrityStatus defines the observed state of FileIntegrity


### PR DESCRIPTION
We added `initialDelay` option to FileIntegrity CRD to allow users to specify the initial delay before the first scan is run. This is useful for environments where the operator is deployed before the cluster is fully ready.
Launch of aide demonset will be delayed according to the value of initialDelay set in FileIntegrity Object.

To launch a FileIntegrity Check for worker nodes with a delay of 100s you can create the following object:

```yaml
apiVersion: fileintegrity.openshift.io/v1alpha1
kind: FileIntegrity
metadata:
  name: worker-fileintegrity
  namespace: openshift-file-integrity
spec:
  nodeSelector:
      node-role.kubernetes.io/worker: ""
  config:
      initialDelay: 100
```