### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "ok-to-test"
+    - "qe-approved"
+    - "px-approved"
+    - "docs-approved"
+  open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: weekly
+  labels:
+    - "ok-to-test"
+    - "ok-to-test"
+    - "qe-approved"
+    - "px-approved"
+    - "docs-approved"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
We configure dependabot for FIO because FIO is hosted under the
openshift org and renovate does seem to require org admin access to be
set up and in general I'm uneasy about configuring an app in the
openshift org.
