### PR TITLE
chore: go fmt fixes

### DIFF
--- a/cmd/manager/daemon.go
+++ b/cmd/manager/daemon.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/manager/daemon_util.go
+++ b/cmd/manager/daemon_util.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/manager/logcollector.go
+++ b/cmd/manager/logcollector.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/manager/logcollector_util.go
+++ b/cmd/manager/logcollector_util.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/manager/loops.go
+++ b/cmd/manager/loops.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/fileintegrity/v1alpha1/groupversion_info.go
+++ b/pkg/apis/fileintegrity/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the fileintegrity v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=fileintegrity.openshift.io
+// +kubebuilder:object:generate=true
+// +groupName=fileintegrity.openshift.io
 package v1alpha1
 
 import (

--- a/tests/framework/projutil.go
+++ b/tests/framework/projutil.go
@@ -134,11 +134,12 @@ func (opts GoCmdOptions) setCmdFields(c *exec.Cmd) {
 }
 
 // From https://github.com/golang/go/wiki/Modules:
-//	You can activate module support in one of two ways:
-//	- Invoke the go command in a directory with a valid go.mod file in the
-//      current directory or any parent of it and the environment variable
-//      GO111MODULE unset (or explicitly set to auto).
-//	- Invoke the go command with GO111MODULE=on environment variable set.
+//
+//		You can activate module support in one of two ways:
+//		- Invoke the go command in a directory with a valid go.mod file in the
+//	     current directory or any parent of it and the environment variable
+//	     GO111MODULE unset (or explicitly set to auto).
+//		- Invoke the go command with GO111MODULE=on environment variable set.
 //
 // GoModOn returns true if Go modules are on in one of the above two ways.
 func GoModOn() (bool, error) {


### PR DESCRIPTION
`make fmt` or `go fmt` keep making these changes locally. They're
non-functional style fixes.
