### PR TITLE
Bump operator-sdk from 1.15.0 to 1.27.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ export NAMESPACE=openshift-file-integrity
 # Operator-sdk variables
 # ======================
 SDK_BIN?=
-SDK_VERSION?=1.15.0
+SDK_VERSION?=1.27.0
 # Ideally this should align with SDK_VERSION, but for now it needs to be newer.
-OPM_VERSION?=1.20.0
+OPM_VERSION?=$(VERSION)
 
 # Test variables
 # ==============


### PR DESCRIPTION
We recently bumped our version of go to 1.19, but we also need to bump
our operator-sdk version to a version that is compatible with go 1.19.

While not doing this doesn't necessarily cause issues. It's to keep versions of golang
used in different parts of the project in sync.
