### PR TITLE
Update golang version in Dockerfile for builds

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Step one: build file-integrity-operator
-FROM golang:1.17 as builder
+FROM golang:1.19 as builder
 USER root
 
 WORKDIR /go/src/github.com/openshift/file-integrity-operator


### PR DESCRIPTION
We have a separate Dockerfile used for building container images during
the release process, which is separate from the Dockerfile we use for CI
(Dockerfile.ci).

We recently updated the version of golang we use to 1.19 by updating
go.mod and the Dockerfile.ci file. But, we didn't update the golang
version for the builds we use during the upstream release process.

I caught this issue as I prepared the 1.2.0 release and noticed failures
building the new container images for that version.

This commit updates the golang version in build/Dockerfile to be
consistent with the version use in the rest of the project.
