### PR TITLE
Use remote detection in release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,13 @@ endif
 
 # Git options.
 GIT_OPTS?=
-# Set this to the remote used for the upstream repo (for release). Use an
-# absolute reference since we don't know if origin is the contributor's fork or
-# if it's the upstream repository.
-GIT_REMOTE?=git@github.com:openshift/file-integrity-operator.git
+# Set this to the remote used for the upstream repo (for release). Different
+# maintainers might use different names for the upstream repository. Since our
+# release process expects maintainers to propose release patches directly to
+# the upstream repository, let's make sure we're proposing it to the right one.
+# We rely on a bash script for this since it's simplier than interating over a
+# list with conditionals in GNU make.
+GIT_REMOTE?=$(shell ./utils/git-remote.sh)
 
 # Image tag to use. Set this if you want to use a specific tag for building
 # or your e2e tests.

--- a/utils/git-remote.sh
+++ b/utils/git-remote.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# git-remote.sh prints the remote associated with the upstream
+# openshift/file-integrity-operator repository. If it can't determine the
+# appropriate remote based on a known URL, it defaults to using "origin", which
+# is backwards compatible with the release process.
+
+REMOTE_URL=origin
+for REMOTE in `git remote`; do
+        URL=`git config --get remote.$REMOTE.url`
+        if [[ "$URL" = "https://github.com/openshift/file-integrity-operator" ]]; then
+                REMOTE_URL=$REMOTE
+                break
+        fi
+done
+echo $REMOTE_URL


### PR DESCRIPTION
Some contributors use different naming conventions and protocols for
their upstream and downstream branchs. Instead of assuming the same
setup for everyone, let's use a script to find which remote name to use
based on the organization and repository, and then call that script from
the release targets.

This makes the release process a little easier for contributors,
regardless of how they have their remotes setup.
