### PR TITLE
Update maintainers

### DIFF
--- a/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
@@ -315,8 +315,8 @@ spec:
   - name: File Integrity Operator documentation
     url: https://docs.openshift.com/container-platform/latest/security/file_integrity_operator/file-integrity-operator-understanding.html
   maintainers:
-  - email: mrogers@redhat.com
-    name: Matt Rogers
+  - email: support@redhat.com
+    name: Red Hat Support
   maturity: alpha
   provider:
     name: Red Hat

--- a/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
@@ -276,8 +276,8 @@ spec:
   - name: File Integrity Operator documentation
     url: https://docs.openshift.com/container-platform/latest/security/file_integrity_operator/file-integrity-operator-understanding.html
   maintainers:
-  - email: mrogers@redhat.com
-    name: Matt Rogers
+  - email: support@redhat.com
+    name: Red Hat Support
   maturity: alpha
   provider:
     name: Red Hat


### PR DESCRIPTION
Point maintains in the CSV to a support list instead of a single point
of contact for scalability reasons.

This makes it easier for users to find help from the CSV in the bundle
image.
