### PR TITLE
Update CI to use RHEL 9 and OpenShift 4.13

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Step one: build file-integrity-operator
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.13 AS builder
 USER root
 
 WORKDIR /go/src/github.com/openshift/file-integrity-operator


### PR DESCRIPTION
This changes accompanies CI changes to start using OpenShift 4.13 with
RHEL 9 base images.

  https://github.com/openshift/release/pull/37184

We want to start testing FIO using RHEL 9 because it relies on AIDE to
detect file system changes. We need to make sure we don't have any
regressions using RHEL 9.
