### PR TITLE
Use RHEL8 for building FIO container images in CI

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Step one: build file-integrity-operator
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.19-openshift-4.13 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.13 AS builder
 USER root
 
 WORKDIR /go/src/github.com/openshift/file-integrity-operator


### PR DESCRIPTION
We recently updating the FIO CI to use RHEL9 nodes. This is important
since the operator is reponsible for file integrity of those nodes. In
that process, we also updated the CI image for FIO to use RHEL 9. This
means the container image is built using RHEL 9, which is completely
separate from the RHEL version of the nodes used in the cluster.

This change updates the Dockerfile CI image to use RHEL8, instead of
RHEL9, since the higher priority is to make sure FIO works against RHEL
9 and not necessarily that it's build *using* RHEL 9.

We will updating FIO container images to use RHEL 9 at a later date.
