### PR TITLE
OCPBUGS-14348 Change the default config file to exclude kubelet CA

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -42,6 +42,7 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 !/hostroot/etc/kubernetes/static-pod-resources
 !/hostroot/etc/kubernetes/aide.*
 !/hostroot/etc/kubernetes/manifests
+!/hostroot/etc/kubernetes/kubelet-ca.crt
 !/hostroot/etc/docker/certs.d
 !/hostroot/etc/selinux/targeted
 !/hostroot/etc/openvswitch/conf.db


### PR DESCRIPTION
We want to exclude the Kubelet CA file from the default config, so the user does not have to reinit the aide database when the cert gets renewed.

Link to the Jira Issue: [OCPBUGS-14348](https://issues.redhat.com/browse/OCPBUGS-14348)