### PR TITLE
Fix metric test logging

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1883,7 +1883,7 @@ func assertEachMetric(t *testing.T, namespace string, expectedMetrics map[string
 		}
 	}
 	if len(metricErrs) > 0 {
-		for err := range metricErrs {
+		for _, err := range metricErrs {
 			t.Log(err)
 		}
 		return errors.New("unexpected metrics value")


### PR DESCRIPTION
The end-to-end tests have a utility that helps assert metrics exist in
the output from the metrics endpoint. This assertion also tracks metric
errors as a slice, and then outputs them before failing the test if the
assertion fails.

However, the current logging only outputs the slice index as it iterates
over the errors, resulting in the follow output in CI failures:

    helpers.go:1887: 0
    helpers.go:1887: 1
    helpers.go:1887: 2
    helpers.go:1887: 3

While we can see something failed, it's not as useful as the actual
value, which is an Error that's more descriptive of the failure.

This commit adjusts the iteration to emit the error instead of the
index.
