### PR TITLE
dependabot: Use dependabot groups to group k8s updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     - "qe-approved"
     - "px-approved"
     - "docs-approved"
+  groups:
+    kubernetes:
+      patterns:
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
   open-pull-requests-limit: 10
 - package-ecosystem: docker
   directory: "/"


### PR DESCRIPTION
Per:
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
