### PR TITLE
Update aide database configuration option

### DIFF
--- a/aide.conf.rhel8
+++ b/aide.conf.rhel8
@@ -4,7 +4,7 @@
 @@define LOGDIR /var/log/aide
 
 # The location of the database to be read.
-database=file:@@{DBDIR}/aide.db.gz
+database_in=file:@@{DBDIR}/aide.db.gz
 
 # The location of the database to be written.
 #database_out=sql:host:port:database:login_name:passwd:table

--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -15,7 +15,7 @@ var aidePauseContainerScript = `#!/bin/sh
 // NOTE: Needs to be in sync with `testAideConfig` in test/e2e/helpers.go, except for the heading comment.
 var DefaultAideConfig = `@@define DBDIR /hostroot/etc/kubernetes
 @@define LOGDIR /hostroot/etc/kubernetes
-database=file:@@{DBDIR}/aide.db.gz
+database_in=file:@@{DBDIR}/aide.db.gz
 database_out=file:@@{DBDIR}/aide.db.gz.new
 gzip_dbout=yes
 verbose=5


### PR DESCRIPTION
Newer versions of aide deprecated the `database` configuration option in
favor of `database_in`.

This commit updates the aide configuration we use so we don't emit a
deprecation warning in the aide logs.
