### PR TITLE
Pin aide version to 0.16.0

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -12,6 +12,7 @@ RUN make build
 
 # Step two: containerize file-integrity-operator and AIDE together
 FROM registry.fedoraproject.org/fedora-minimal:latest
+RUN microdnf -y install aide-0.16
 RUN microdnf -y install aide golang && microdnf clean all
 
 ENV OPERATOR=/usr/local/bin/file-integrity-operator \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,6 +12,7 @@ RUN make build
 
 # Step two: containerize file-integrity-operator and AIDE together
 FROM registry.fedoraproject.org/fedora-minimal:latest
+RUN microdnf -y install aide-0.16
 RUN microdnf -y install aide golang && microdnf clean all
 
 ENV OPERATOR=/usr/local/bin/file-integrity-operator \


### PR DESCRIPTION
FIO makes some assumption about aide configuration. Newer version of
aide have backwards incompatible changes with older configurations that
FIO is using, causing issues with CI. We will need to handle the
configuration migration in the operator to allow for smooth migration.

This commit pins the version of aide we're using to 0.16.0 for now until
we can handle the configuration migration and use a newer version of
aide.

Fixes #396
