### PR TITLE
Add clean-images command to purge build env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ else
 RUNTIME_BUILD_CMD=build
 endif
 
+ifeq ($(RUNTIME),buildah)
+RUNTIME_PRUNE_CMD=prune --all --force
+else
+RUNTIME_PRUNE_CMD=system prune --all --force
+endif
+
 ifeq ($(RUNTIME), podman)
     LOGIN_PUSH_OPTS="--tls-verify=false"
 else ifeq ($(RUNTIME), docker)
@@ -188,6 +194,10 @@ clean-kustomize: ## Reset kustomize changes in the repo.
 .PHONY: clean-controller-gen
 clean-controller-gen: ## Remove the controller-gen build
 	rm -f $(CONTROLLER_GEN)
+
+.PHONY: clean-images
+clean-images: ## Remove all containers, images, pods and networks.
+	$(RUNTIME) $(RUNTIME_PRUNE_CMD)
 
 .PHONY: simplify
 simplify: ## Run go fmt -s against code.


### PR DESCRIPTION
Add Make command to remove all unused containers, images, pods and networks.
Sometimes the build may end up using a cached stale image for no apparent reason.
This command facilitates purging images used to build the operator and pulling fresh images.