### PR TITLE
Update e2e test config

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -116,6 +116,7 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 !/hostroot/etc/kubernetes/static-pod-resources
 !/hostroot/etc/kubernetes/aide.*
 !/hostroot/etc/kubernetes/manifests
+!/hostroot/etc/kubernetes/kubelet-ca.crt
 !/hostroot/etc/docker/certs.d
 !/hostroot/etc/selinux/targeted
 !/hostroot/etc/openvswitch/conf.db


### PR DESCRIPTION
We had a miss match for the aide conf file in our e2e test, it is causing issues sometimes, this config file should match [default config](https://github.com/openshift/file-integrity-operator/blob/df11364db9d90bbac38d6d62dd148cc6cf0067b0/pkg/controller/fileintegrity/config_defaults.go#L16)