### PR TITLE
OCPBUGS-17129: Ignore MCO node annotation files

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -49,6 +49,7 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 !/hostroot/etc/kubernetes/cni/net.d
 !/hostroot/etc/kubernetes/cni/net.d/*
 !/hostroot/etc/machine-config-daemon/currentconfig$
+!/hostroot/etc/machine-config-daemon/node-annotation.json*
 !/hostroot/etc/pki/ca-trust/extracted/java/cacerts$
 !/hostroot/etc/cvo/updatepayloads
 


### PR DESCRIPTION
Machine config operator uses files on the host to cache annotations. The
file integrity operator will throw integrity errors if a new node is
spun up and added to the cluster depending.

Since OpenShift's MCO is responsible for these files, let's exclude them
from integrity checks like we do other MCO configuration files.
