### PR TITLE
tests: Set logger to an empty sink in tests

### DIFF
--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	"github.com/go-logr/logr"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	log "github.com/sirupsen/logrus"
 	extscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -167,6 +169,15 @@ func newFramework(opts *frameworkOpts) (*Framework, error) {
 		restMapper:         restMapper,
 		skipCleanupOnError: opts.skipCleanupOnError,
 	}
+
+	// This is required because controller-runtime expects its consumers to
+	// set a logger through log.SetLogger within 30 seconds of the program's
+	// initalization. If not set, the entire debug stack is printed as an
+	// error, see: https://github.com/kubernetes-sigs/controller-runtime/blob/ed8be90/pkg/log/log.go#L59
+	// Since we have our own logging and don't care about controller-runtime's
+	// logger, we configure it's logger to do nothing.
+	ctrllog.SetLogger(logr.New(ctrllog.NullLogSink{}))
+
 	return framework, nil
 }
 


### PR DESCRIPTION
This is pretty much
https://github.com/fluxcd/flux2/commit/aa65589391db2433691d8cebde5c77c090cae3a9
reused.

The new controller-runtime version requires that the logger is set or
else there's a stack trace printed. Since even the original code doesn't
use any logger for tests, let's just use null logger with the new
version as well.
