### PR TITLE
OCPBUGS-18532: exclude file for ServiceMesh Operator

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -52,6 +52,6 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 !/hostroot/etc/machine-config-daemon/node-annotation.json*
 !/hostroot/etc/pki/ca-trust/extracted/java/cacerts$
 !/hostroot/etc/cvo/updatepayloads
-
+!/hostroot/etc/cni/multus/net.d/*
 # Catch everything else in /etc
 /hostroot/etc/    CONTENT_EX`

--- a/tests/framework/resource.go
+++ b/tests/framework/resource.go
@@ -22,6 +22,18 @@ import (
 
 const maxExecutiveEmpties = 100
 
+var serviceMeshOperatorSubscription = `apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemesh
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: servicemeshoperator
+  source: redhat-operators 
+  sourceNamespace: openshift-marketplace 
+`
+
 // Scanner scans a yaml manifest file for manifest tokens delimited by "---".
 // See bufio.Scanner for semantics.
 type Scanner struct {
@@ -215,4 +227,8 @@ func (ctx *Context) InitializeClusterResources(cleanupOptions *CleanupOptions) e
 		return fmt.Errorf("failed to read namespaced manifest: %w", err)
 	}
 	return ctx.createFromYAML(namespacedYAML, false, cleanupOptions)
+}
+
+func (ctx *Context) InitializeServiceMeshClusterResources(cleanupOptions *CleanupOptions) error {
+	return ctx.createFromYAML([]byte(serviceMeshOperatorSubscription), true, cleanupOptions)
 }


### PR DESCRIPTION
we are excluding `/hostroot/etc/cni/multus/net.d` from the default aide.conf file so that ServiceMesh Operator can run without triggering FIO failures.

[OCPBUGS-18532](https://issues.redhat.com/browse/OCPBUGS-18532)