### PR TITLE
Disable http2 as default for webhook

### DIFF
--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -189,6 +189,7 @@ func (m *Metrics) Start(ctx context.Context) error {
 
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
 	}
 	tlsConfig = libgocrypto.SecureTLSConfig(tlsConfig)
 	server := &http.Server{


### PR DESCRIPTION
In order to address CVE-2023-44487, we need to disable the http2 by default in webhook.