### PR TITLE
Exclude multus certs from scanning

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -52,6 +52,7 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 !/hostroot/etc/machine-config-daemon/node-annotation.json*
 !/hostroot/etc/pki/ca-trust/extracted/java/cacerts$
 !/hostroot/etc/cvo/updatepayloads
+!/hostroot/etc/cni/multus/certs/*
 
 # Catch everything else in /etc
 /hostroot/etc/    CONTENT_EX`


### PR DESCRIPTION
File Integrity Operator on OpenShift trigger warnings on changes on the folder /hostroot/etc/cni/multus/certs

This folder should be excluded from the scan.