### PR TITLE
Use ubi images instead of fedora minimal

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -11,8 +11,7 @@ COPY . .
 RUN make build
 
 # Step two: containerize file-integrity-operator and AIDE together
-FROM registry.fedoraproject.org/fedora-minimal:latest
-RUN microdnf -y install aide-0.16
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf -y install aide golang && microdnf clean all
 
 ENV OPERATOR=/usr/local/bin/file-integrity-operator \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,8 +11,7 @@ COPY . .
 RUN make build
 
 # Step two: containerize file-integrity-operator and AIDE together
-FROM registry.fedoraproject.org/fedora-minimal:latest
-RUN microdnf -y install aide-0.16
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf -y install aide golang && microdnf clean all
 
 ENV OPERATOR=/usr/local/bin/file-integrity-operator \


### PR DESCRIPTION
Fedora repositories are using newer versions of AIDE that we don't
support with FIO, which will cause issues running the operator because
it doesn't know how to configure AIDE 0.18.

This commit updates the dockerfiles to use UBI images which provide AIDE
0.16, which is compatible with FIO and gives us some time to implement
support for 0.18.
