### PR TITLE
CMP-2175: Implement support for replaces attribute in CSV

### DIFF
--- a/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
@@ -282,4 +282,5 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/openshift/file-integrity-operator
-  version: 0.1.22
+  version: 1.3.3
+  replaces: file-integrity-operator.v1.2.1

--- a/utils/get-current-version.sh
+++ b/utils/get-current-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+CSV="$ROOT_DIR/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml"
+
+OLD_VERSION=$(yq -r '.spec.version' "$CSV")
+echo $OLD_VERSION


### PR DESCRIPTION
Doing this makes it so that OLM can build dependency graphs between
operator versions, which make it easier for users perform installs on
disconnected environments and upgrades.
