### PR TITLE
Use Fedora 37 for AIDE 0.16

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -11,7 +11,7 @@ COPY . .
 RUN make build
 
 # Step two: containerize file-integrity-operator and AIDE together
-FROM registry.fedoraproject.org/fedora-minimal:latest
+FROM registry.fedoraproject.org/fedora-minimal:37
 RUN microdnf -y install aide-0.16
 RUN microdnf -y install aide golang && microdnf clean all
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN make build
 
 # Step two: containerize file-integrity-operator and AIDE together
-FROM registry.fedoraproject.org/fedora-minimal:latest
+FROM registry.fedoraproject.org/fedora-minimal:37
 RUN microdnf -y install aide-0.16
 RUN microdnf -y install aide golang && microdnf clean all
 


### PR DESCRIPTION
Newer versions of Fedora have AIDE 0.18, which breaks with FIO due to
backwards incompatible configuration changes with AIDE 0.18.

This commit uses an older version of fedora so we can still build FIO
until integrate a newer version of AIDE.
