### PR TITLE
Update manifests for kubebuilder version

### DIFF
--- a/config/crd/bases/fileintegrity.openshift.io_fileintegrities.yaml
+++ b/config/crd/bases/fileintegrity.openshift.io_fileintegrities.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: fileintegrities.fileintegrity.openshift.io
 spec:
   group: fileintegrity.openshift.io

--- a/config/crd/bases/fileintegrity.openshift.io_fileintegritynodestatuses.yaml
+++ b/config/crd/bases/fileintegrity.openshift.io_fileintegritynodestatuses.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: fileintegritynodestatuses.fileintegrity.openshift.io
 spec:
   group: fileintegrity.openshift.io


### PR DESCRIPTION
Makefile tooling is generating manifests with older kubebuilder
versions. Let's just update these so they're up-to-date with the version
we're using.
