### PR TITLE
OCPBUGS-31257: Exclude additional files in default aide conf

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -52,6 +52,9 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 !/hostroot/etc/machine-config-daemon/node-annotation.json*
 !/hostroot/etc/pki/ca-trust/extracted/java/cacerts$
 !/hostroot/etc/cvo/updatepayloads
+!/hostroot/etc/cni/multus/certs
+!/hostroot/etc/kubernetes/compliance-operator
+!/hostroot/etc/kubernetes/node-feature-discovery
 
 # Catch everything else in /etc
 /hostroot/etc/    CONTENT_EX`

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -130,6 +130,9 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 !/hostroot/etc/machine-config-daemon/currentconfig$
 !/hostroot/etc/pki/ca-trust/extracted/java/cacerts$
 !/hostroot/etc/cvo/updatepayloads
+!/hostroot/etc/cni/multus/certs
+!/hostroot/etc/kubernetes/compliance-operator
+!/hostroot/etc/kubernetes/node-feature-discovery
 
 # Catch everything else in /etc
 /hostroot/etc/    CONTENT_EX`


### PR DESCRIPTION
We are going to exlucde following in the default aide conf: 
`!/hostroot/etc/cni/multus/certs` for the OVN-Kubernetes CNI
`!/hostroot/etc/kubernetes/compliance-operator` for the Compliance Operator check runtime kubeletconfig `!/hostroot/etc/kubernetes/node-feature-discovery` for the Node Feature Discovery Operator

https://issues.redhat.com/browse/OCPBUGS-31257