### PR TITLE
Only set node selectors for OpenShift deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,11 @@ bundle: check-operator-version operator-sdk manifests update-skip-range kustomiz
 	$(SDK_BIN) generate kustomize manifests --apis-dir=./pkg/apis -q
 	@echo "kustomize using deployment image $(IMG)"
 	cd config/manager && $(KUSTOMIZE) edit set image $(APP_NAME)=$(IMG)
+	if [ $(PLATFORM) = "openshift" ]; then \
+                sed -i 's%../default-bundle%../openshift-bundle%' config/manifests/kustomization.yaml; \
+        fi
 	$(KUSTOMIZE) build config/manifests | $(SDK_BIN) generate bundle -q $(BUNDLE_SA_OPTS) --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	git restore config/manifests/kustomization.yaml
 	$(SDK_BIN) bundle validate ./bundle
 
 .PHONY: bundle-image

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -53,12 +53,7 @@ spec:
           secret:
             secretName: file-integrity-operator-serving-cert
             optional: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       tolerations:
-        - key: "node-role.kubernetes.io/master"
-          operator: "Exists"
-          effect: "NoSchedule"
         - key: "node.kubernetes.io/unreachable"
           operator: "Exists"
           effect: "NoExecute"

--- a/config/openshift-bundle/kustomization.yaml
+++ b/config/openshift-bundle/kustomization.yaml
@@ -1,0 +1,13 @@
+namespace: openshift-compliance
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+- ../ns
+
+patches:
+- path: manager_patch.yaml
+  target:
+    kind: Deployment
+    name: file-integrity-operator

--- a/config/openshift-bundle/manager_patch.yaml
+++ b/config/openshift-bundle/manager_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: file-integrity-operator
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"


### PR DESCRIPTION
By default, the File Integrity Operator would set node selectors and
taints that would only allow it to schedule on `master` nodes. While
this is fine for OpenShift environments, some additional environments we
test on, like Red Hat OpenShift on AWS (ROSA), don't provide `master`
nodes at all.

To accomodate this in our testing and tooling, this commit removes the
node selector and taint from the default bundle, and moves it into an
OpenShift-specific bundle where it will still get used for OpenShift
deploy paths and bundles.

This will be more useful in a future patch that implements support for
running File Integrity Operator end-to-end testing on ROSA HCP, which
only provides `worker` nodes and not `master` nodes.
