### PR TITLE
Exclude MCO registry secret from integrity checks

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -55,6 +55,7 @@ CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
 !/hostroot/etc/cni/multus/certs
 !/hostroot/etc/kubernetes/compliance-operator
 !/hostroot/etc/kubernetes/node-feature-discovery
+!/hostroot/etc/mco/internal-registry-pull-secret.json$
 
 # Catch everything else in /etc
 /hostroot/etc/    CONTENT_EX`


### PR DESCRIPTION
We're noticing some issues in CI where tests time out because node never
reach their desired state. We've also noticed MCO making changes to a
file that was previously monitored, causing failures we weren't
expecting.

This commit attempts to fix the issue by excluding the MCO file in
question so it stops raising false negative results in the e2e suite.
