### PR TITLE
AIDE 0.18 e2e

### DIFF
--- a/Dockerfile.AIDE0.18.ci
+++ b/Dockerfile.AIDE0.18.ci
@@ -1,0 +1,31 @@
+# Step one: build file-integrity-operator
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
+USER root
+
+WORKDIR /go/src/github.com/openshift/file-integrity-operator
+
+ENV GOFLAGS="-mod=vendor"
+
+COPY . .
+
+RUN make build
+
+# Step two: containerize file-integrity-operator and AIDE together
+FROM registry.fedoraproject.org/fedora-minimal:latest
+RUN microdnf -y install aide
+RUN aide -v | grep -q '0.18' || (echo "Aide version is not 0.18 but $(aide -v)" && exit 1)
+RUN microdnf -y install aide golang && microdnf clean all
+
+ENV OPERATOR=/usr/local/bin/file-integrity-operator \
+    USER_UID=1001 \
+    USER_NAME=file-integrity-operator
+    AIDE_VERSION=0.18
+
+# install operator binary
+COPY --from=builder /go/src/github.com/openshift/file-integrity-operator/build/bin/manager ${OPERATOR}
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -304,7 +304,7 @@ func (r *FileIntegrityReconciler) reconcileUserConfig(instance *v1alpha1.FileInt
 		if !hasDefaultConfig {
 			// The configuration was previously replaced. We want to restore it now.
 			reqLogger.Info("Restoring the AIDE configuration defaults.")
-			if err := r.updateAideConfig(currentConfig, DefaultAideConfig, ""); err != nil {
+			if err := r.updateAideConfig(currentConfig, GetAideConfigDefault(), ""); err != nil {
 				return false, err
 			}
 			return true, nil
@@ -656,7 +656,7 @@ func defaultAIDEConfigMap(name string) *corev1.ConfigMap {
 			},
 		},
 		Data: map[string]string{
-			common.DefaultConfDataKey: DefaultAideConfig,
+			common.DefaultConfDataKey: GetAideConfigDefault(),
 		},
 	}
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -672,7 +672,7 @@ func TestFileIntegrityConfigurationIgnoreMissing(t *testing.T) {
 	}
 
 	if err := pollUntilConfigMapDataMatches(t, f, namespace, testName, common.DefaultConfDataKey,
-		fileintegrity2.DefaultAideConfig, time.Second*5, time.Minute*5); err != nil {
+		fileintegrity2.GetAideConfigDefault(), time.Second*5, time.Minute*5); err != nil {
 		t.Errorf("Timeout waiting for configMap data to match")
 	}
 }


### PR DESCRIPTION
This PR adds the dockerfile that builds operator image with the AIDE 0.18, also replacing 0.16 config file with the 0.18 conf file using the migration logic depends on value of AIDE_VERSION. We will use 0.16 as default value if not set. This is for us to have CI to test AIDE config.

We will need to merge this one and test on https://github.com/openshift/release/pull/54911