### PR TITLE
Skip test that require machine configs on ROSA HCP

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -999,6 +999,9 @@ func TestFileIntegrityLogCompress(t *testing.T) {
 // NOTE: This test is run last because it modifies the node and causes restarts
 func TestFileIntegrityAcceptsExpectedChange(t *testing.T) {
 	f, testctx, namespace := setupTest(t)
+	if testctx.GetPlatform() == "rosa" {
+		t.Skip("Skipping because this test relies of Machine Configs, which are not supported on ROSA HCP environments.")
+	}
 	testName := testIntegrityNamePrefix + "-nodechange"
 	setupFileIntegrity(t, f, testctx, testName, namespace, "", defaultTestGracePeriod) // empty selector key to match all nodes
 	defer testctx.Cleanup()


### PR DESCRIPTION
We recently added support for running tests on ROSA HCP, which doesn't
support some objects like Machine Configs:

  https://github.com/openshift/release/pull/53502

Because of this, the TestFileIntegrityAcceptsExpectedChange test is
failing because it expects to create a Machine Config as a dependency
for the test.

This commit updates the test to check if we're running on ROSA HCP, and
if so, skip the test.
