### PR TITLE
Fix a missing back slash in aide0.18 dockerfile

### DIFF
--- a/Dockerfile.AIDE0.18.ci
+++ b/Dockerfile.AIDE0.18.ci
@@ -18,7 +18,7 @@ RUN microdnf -y install aide golang && microdnf clean all
 
 ENV OPERATOR=/usr/local/bin/file-integrity-operator \
     USER_UID=1001 \
-    USER_NAME=file-integrity-operator
+    USER_NAME=file-integrity-operator \
     AIDE_VERSION=0.18
 
 # install operator binary


### PR DESCRIPTION
We are adding a missing `\` in the aide 0.18 dockerfile.