### PR TITLE
Use latest in the CSV instead of a version tag

### DIFF
--- a/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ spec:
                   value: file-integrity-operator
                 - name: RELATED_IMAGE_OPERATOR
                   value: quay.io/file-integrity-operator/file-integrity-operator:latest
-                image: quay.io/file-integrity-operator/file-integrity-operator:1.3.0
+                image: quay.io/file-integrity-operator/file-integrity-operator:latest
                 imagePullPolicy: Always
                 name: file-integrity-operator
                 resources:


### PR DESCRIPTION
This makes it so that the replace logic also replaces the deployment
image in addition to the related image. This is necessary CI to work
properly, because it needs to be able to replace all images in the CSV
with a build from CI.
