### PR TITLE
OCPBUGS-42807: Preserve metrics when pod crashes

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -568,6 +568,7 @@ func TestFileIntegrityMetricsResetPersistence(t *testing.T) {
 	}
 	t.Log("Operator pod restarted")
 
+	time.Sleep(5 * time.Second)
 	// check again the metrics, they should still be there
 	err = assertEachMetric(t, namespace, expectedMetrics)
 	if err != nil {

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -70,7 +70,7 @@ const (
 	certRotationAnnotationKey      = "auth.openshift.io/certificate-not-after"
 	defaultTestGracePeriod         = 20
 	defaultTestInitialDelay        = 0
-	testInitialDelay               = 30
+	testInitialDelay               = 120
 	deamonsetWaitTimeout           = 30 * time.Second
 	legacyReinitOnHost             = "/hostroot/etc/kubernetes/aide.reinit"
 	metricsTestCRBName             = "fio-metrics-client"


### PR DESCRIPTION
The metric `file_integrity_operator_node_failed` was being reset after the File Integrity Operator pod restarted, causing the `NodeHasIntegrityFailure` alert to clear despite failures persisting in `fileintegritynodestatuses`. This fix ensures that the operator retrieves the status of existing node failures and re-triggers the alert as needed, maintaining consistency in node failure detection.