### PR TITLE
Add a Makefile target to verify bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,10 @@ bundle: check-operator-version operator-sdk manifests update-skip-range kustomiz
 	git restore config/manifests/kustomization.yaml
 	$(SDK_BIN) bundle validate ./bundle
 
+.PHONY: verify-bundle
+verify-bundle: bundle ## Verify the bundle doesn't alter the state of the tree
+	hack/tree-status
+
 .PHONY: bundle-image
 bundle-image: bundle ## Build the bundle image.
 	$(RUNTIME) $(RUNTIME_BUILD_CMD) -f bundle.Dockerfile -t $(BUNDLE_IMG) .

--- a/hack/tree-status
+++ b/hack/tree-status
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATUS=$(git status --porcelain)
+if [[ -z $STATUS ]]; then
+    echo tree is clean
+else
+    echo tree is dirty, please commit all changes
+    echo "$STATUS"
+    git diff
+    exit 1
+fi


### PR DESCRIPTION
We don't have any CI that checks to make sure the bundle stays
up-to-date with PRs that may be changing the bundle. This usually
results in dirty local builds because running `make bundle` will
generate new bundles from what is kept in source based on other parts
othe project, or the operator-sdk version.

This commit adds in a target to run the `bundle` and then verify there
haven't been any changes. We can wire this up to CI to make it easier to
catch bundle changes sooner.
