### PR TITLE
Reduce initial install delay in e2e

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -68,7 +68,7 @@ const (
 	certRotationAnnotationKey      = "auth.openshift.io/certificate-not-after"
 	defaultTestGracePeriod         = 20
 	defaultTestInitialDelay        = 0
-	testInitialDelay               = 180
+	testInitialDelay               = 30
 	deamonsetWaitTimeout           = 30 * time.Second
 	legacyReinitOnHost             = "/hostroot/etc/kubernetes/aide.reinit"
 	metricsTestCRBName             = "fio-metrics-client"


### PR DESCRIPTION
We can shorten the run time of this particular test by not waiting as
long for the operator to install.
