### PR TITLE
Print node scan results when scan not successful

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1548,6 +1548,11 @@ func assertNodesConditionIsSuccess(t *testing.T, f *framework.Framework, integri
 		for nodeName, status := range latestStatuses {
 			if status.Condition != v1alpha1.NodeConditionSucceeded {
 				lastErr = fmt.Errorf("status.nodeStatus for node %s NOT SUCCESS: But instead %s", nodeName, status.Condition)
+				cm, getErr := f.KubeClient.CoreV1().ConfigMaps(namespace).Get(goctx.TODO(), fmt.Sprintf("aide-%s-%s-failed", integrityName, nodeName), metav1.GetOptions{})
+				if getErr != nil {
+					lastErr = fmt.Errorf("could not find node status configmap for %s", nodeName)
+				}
+				t.Logf("Node Status:\n%s", cm.Data["integritylog"])
 				return false, nil
 
 			}


### PR DESCRIPTION
Let's print out the scan result when a node scan result is not success.
This helps us out understand what are the issues in infra or FIO when a test that is expected pass fails.