### PR TITLE
Annotate the file to nudge after operator builds

### DIFF
--- a/.tekton/file-integrity-operator-push.yaml
+++ b/.tekton/file-integrity-operator-push.yaml
@@ -5,6 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/openshift/file-integrity-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.openshift.io/build-nudge-files: "bundle-hack/update_csv.py"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"


### PR DESCRIPTION
Whenever an operator build on push events is successful the PULLSPEC reference in update_csv.py will be updated.