### PR TITLE
Extend a few more timeout limits

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1108,7 +1108,7 @@ func TestFileIntegrityNodeScaling(t *testing.T) {
 	if removedNodeName == "" {
 		t.Fatal("Failed to scale down worker machineset")
 	}
-	assertNodeStatusForRemovedNode(t, f, testName, namespace, removedNodeName, 2*time.Second, 5*time.Minute)
+	assertNodeStatusForRemovedNode(t, f, testName, namespace, removedNodeName, 2*time.Second, 10*time.Minute)
 }
 
 // This checks test for roating kube-apiserver-to-kubelet-client-ca certificate

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	pollInterval                   = time.Second * 2
-	pollTimeout                    = time.Minute * 5
+	pollTimeout                    = time.Minute * 10
 	retryInterval                  = time.Second * 5
 	timeout                        = time.Minute * 30
 	cleanupRetryInterval           = time.Second * 1


### PR DESCRIPTION
Increase a few more timeouts based on testing results.
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_file-integrity-operator/598/pull-ci-openshift-file-integrity-operator-master-e2e-aws/1852349359656538112
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_file-integrity-operator/589/pull-ci-openshift-file-integrity-operator-master-e2e-aws/1852323147982835712
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_file-integrity-operator/584/pull-ci-openshift-file-integrity-operator-master-e2e-aws/1852315083271573504
