### PR TITLE
Bump version to 1.3.5-dev

### DIFF
--- a/bundle.openshfit.Dockerfile
+++ b/bundle.openshfit.Dockerfile
@@ -5,18 +5,20 @@ RUN pip3 install --upgrade pip && pip3 install ruamel.yaml==0.17.9
 # Use a new stage to enable caching of the package installations for local development
 FROM builder-runner as builder
 
+ARG FIO_VERSION="1.3.5-dev"
+
 COPY ./bundle-hack .
 COPY ./bundle/icons ./icons
 COPY ./bundle/manifests ./manifests
 COPY ./bundle/metadata ./metadata
 
-RUN ./update_csv.py ./manifests 1.3.4
+RUN ./update_csv.py ./manifests ${FIO_VERSION}
 RUN ./update_bundle_annotations.sh
 
 FROM scratch
 
 LABEL name=openshift-file-integrity-operator-bundle
-LABEL version=1.3.4
+LABEL version=${FIO_VERSION}
 LABEL summary='OpenShift File Integrity Operator'
 LABEL maintainer='Infrastructure Security and Compliance Team <isc-team@redhat.com>'
 

--- a/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
@@ -19,8 +19,8 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    createdAt: "2024-05-13T22:06:52Z"
-    olm.skipRange: ">=1.0.0 <1.3.4"
+    createdAt: "2024-11-08T11:50:24Z"
+    olm.skipRange: '>=1.0.0 <1.3.5-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-file-integrity
     operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
@@ -36,7 +36,7 @@ metadata:
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
     operatorframework.io/os.zos: supported
-  name: file-integrity-operator.v1.3.4
+  name: file-integrity-operator.v1.3.5-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -325,5 +325,5 @@ spec:
   relatedImages:
     - image: quay.io/file-integrity-operator/file-integrity-operator:latest
       name: operator
-  version: 1.3.4
-  replaces: file-integrity-operator.v1.3.3
+  version: 1.3.5-dev
+  replaces: file-integrity-operator.v1.3.4

--- a/catalog/preamble.json
+++ b/catalog/preamble.json
@@ -13,8 +13,8 @@
     "package": "file-integrity-operator",
     "entries": [
         {
-            "name": "file-integrity-operator.v1.3.4",
-            "skipRange": ">=1.0.0 <1.3.4"
+            "name": "file-integrity-operator.v1.3.5-dev",
+            "skipRange": ">=1.0.0 <1.3.5-dev"
         }
     ]
 }

--- a/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=1.0.0 <1.3.4'
+    olm.skipRange: '>=1.0.0 <1.3.5-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-file-integrity
     operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'

--- a/version.Makefile
+++ b/version.Makefile
@@ -2,4 +2,4 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
-VERSION?=1.3.4
+VERSION?=1.3.5-dev

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.3.4"
+	Version = "1.3.5-dev"
 )


### PR DESCRIPTION
This will allow us to differentiate the upstream builds from latest released version and the next version.