### PR TITLE
OCPBUGS-36483: Fix new added node issue

### DIFF
--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -869,8 +869,7 @@ func aideDaemonset(dsName string, fi *v1alpha1.FileIntegrity, operatorImage stri
 								fi`,
 							},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: &priv,
-								RunAsUser:  &runAs,
+								RunAsUser: &runAs,
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -856,6 +856,41 @@ func aideDaemonset(dsName string, fi *v1alpha1.FileIntegrity, operatorImage stri
 					NodeSelector:       fi.Spec.NodeSelector,
 					Tolerations:        fi.Spec.Tolerations,
 					ServiceAccountName: common.DaemonServiceAccountName,
+					InitContainers: []corev1.Container{
+						{
+							Name:  "check-folder",
+							Image: common.GetComponentImage(operatorImage, common.OPERATOR),
+							Command: []string{
+								"sh",
+								"-c",
+								`if [ ! -d "/host/etc/kubernetes/static-pod-resources" ]; then
+									echo "Directory /etc/kubernetes/static-pod-resources does not exist, exiting.";
+									exit 1;
+								fi`,
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &priv,
+								RunAsUser:  &runAs,
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("10Mi"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("50Mi"),
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:             "hostroot",
+									MountPath:        "/host",
+									MountPropagation: &hostToContainer,
+								},
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
`/etc/kubernetes/static-pod-resource` is being created after a new node is added, this cause the link count change in the aide checks and resulting a failures. The PR added a init pod to check for that before running aide daemonset.