### PR TITLE
CMP-3381: Update the bundle pipeline to only run for specific changes

### DIFF
--- a/.tekton/file-integrity-operator-bundle-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-push.yaml
@@ -7,7 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "master"
+      == "master" && ( "bundle-hack/update_csv.go".pathChanged() || ".tekton/file-integrity-operator-bundle-push.yaml".pathChanged()
+      || "bundle.openshift.Dockerfile".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: file-integrity-operator


### PR DESCRIPTION
We only really need to build the bundle image when the operator image
reference changes, or if the build pipline configuration change for the
bundle build.
