### PR TITLE
CMP-3381: Configure Konflux to bump image SHAs

### DIFF
--- a/.tekton/file-integrity-operator-push.yaml
+++ b/.tekton/file-integrity-operator-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/openshift/file-integrity-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    build.appstudio.openshift.io/build-nudge-files: "bundle-hack/update_csv.py"
+    build.appstudio.openshift.io/build-nudge-files: "bundle-hack/update_csv.go"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"


### PR DESCRIPTION
https://github.com/openshift/file-integrity-operator/pull/598 refactored
the update_csv.py to update_csv.go. This commit updates the nudge to
account for that so we can have Konflux propose image updates
automatically.
