### PR TITLE
Fix bundle file path for cel expression

### DIFF
--- a/.tekton/file-integrity-operator-bundle-1-3-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-1-3-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.3" && ( "bundle-hack/update_csv.go".pathChanged() || ".tekton/file-integrity-operator-bundle-push.yaml".pathChanged()
+      == "release-1.3" && ( "bundle-hack/update_csv.go".pathChanged() || ".tekton/file-integrity-operator-bundle-1-3-push.yaml".pathChanged()
       || "bundle.openshift.Dockerfile".pathChanged())
   creationTimestamp: null
   labels:


### PR DESCRIPTION
We updated this pipeline to use the release-1.3 branch, but we were using the older master pipeline name for the trigger. Instead, we want to make sure we trigger this pipeline when it's changed, so let's update the file path to point to the correct pipeline.