### PR TITLE
Update pipeline runs to include branch name as image tag

### DIFF
--- a/.tekton/file-integrity-operator-1-3-push.yaml
+++ b/.tekton/file-integrity-operator-1-3-push.yaml
@@ -424,6 +424,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-bundle-1-3-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-1-3-push.yaml
@@ -409,6 +409,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-bundle-master-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-master-push.yaml
@@ -409,6 +409,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-bundle-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-push.yaml
@@ -409,6 +409,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-master-push.yaml
+++ b/.tekton/file-integrity-operator-master-push.yaml
@@ -424,6 +424,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-push.yaml
+++ b/.tekton/file-integrity-operator-push.yaml
@@ -424,6 +424,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
By adding the branch name to the most recent builds on push events through Konflux, we can make it easier to fetch the latest builds on a given branch. For example, we can fetch them using the `master` tag or the latest 1.3 release candidate using `release-1.3` for both the bundle and the operator.

Adding this tag makes it easier to fetch the latest images from other locations, like the FBC repository where we need to find the digest to build the appropriate index image.