### PR TITLE
Block MD5 without failing AIDE

### DIFF
--- a/cmd/manager/daemon_util.go
+++ b/cmd/manager/daemon_util.go
@@ -106,12 +106,6 @@ func runAideInitDBCmd(ctx context.Context, c *daemonConfig) error {
 		// #nosec
 		cmd := exec.CommandContext(ctx, "aide", "-c", configPath, "-i")
 
-		// Pre-load the MD5 guard for this *one* exec.
-		// Append to, don’t overwrite, any existing LD_PRELOAD.
-		env := os.Environ()
-		env = append(env, "LD_PRELOAD="+common.MD5_GUARD_LIB)
-		cmd.Env = env
-
 		err := cmd.Run()
 		exit := common.GetAideExitCode(err)
 

--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -913,6 +913,10 @@ func aideDaemonset(dsName string, fi *v1alpha1.FileIntegrity, operatorImage stri
 									Name:  "GODEBUG",
 									Value: "madvdontneed=1",
 								},
+								{
+									Name:  "LD_PRELOAD",
+									Value: common.MD5_GUARD_LIB,
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
Instead of hard exist the program, we will disable the AIDE on FIPS mode without failing the AIDE program in most cases, so AIDE will run without the MD5

```
sh-5.1# LD_PRELOAD=/opt/libaide_md5_guard.so aide -i ; echo $? [md-guard] Attempt to enable MD5 in FIPS — soft block gcry_md_enable 1 failed
Start timestamp: 2025-05-29 07:35:03 +0000 (AIDE 0.16) AIDE initialized database at /var/lib/aide/aide.db.new.gz

Number of entries:      2845

--------------------------------------------------- The attributes of the (uncompressed) database(s):
---------------------------------------------------

/var/lib/aide/aide.db.new.gz
  SHA1     : XKhXEl5aBIIrGKayqdKt9lNVL+0=
  SHA256   : GkEwcPjSe9XItfcYBF3/U3xF040Pt4ay
             SfBqOomyyQc=
  SHA512   : 2FXAGkolRaVqx6WpMxM4uAaK5uMGMPuB
             Unu0CuIh5mRLHTCEKIKfTeij0c1fbdzx
             YisaoKGncm1D9tuSg+zqSw==

example of running without it:

sh-5.1# aide -i -c /config/aide.conf
Start timestamp: 2025-05-29 07:50:00 +0000 (AIDE 0.16) AIDE initialized database at /hostroot/etc/kubernetes/aide.db.gz.new

Number of entries:      37398

--------------------------------------------------- The attributes of the (uncompressed) database(s):
---------------------------------------------------

/hostroot/etc/kubernetes/aide.db.gz.new
  MD5      : nUCHBE4M48vQIKmlbbY/8g==
  SHA1     : +E3jQvmy/RXHy+ZSQYAzRF3n584=
  SHA256   : 3F2GQAq1ZuoYkWZkKNI+NqGq57133Q77
             /mOh4/8HCiM=
  SHA512   : ijKoliE+7dsfKUvMoSdLqJ6h7Jmm9Rhu
             k/8iYawLafQZFFQRn5cHaW+SNBW1FkY7
             2MeTILkSERryGO12updD6w==
```