### PR TITLE
Add licenses dir with operator LICENSE

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -45,6 +45,7 @@ ENV OPERATOR=/usr/local/bin/file-integrity-operator \
 
 # install operator binary
 COPY --from=builder /go/src/github.com/openshift/file-integrity-operator/build/bin/manager ${OPERATOR}
+COPY --from=builder /go/src/github.com/openshift/file-integrity-operator/LICENSE /licenses/LICENSE
 COPY --from=builder /go/src/github.com/openshift/file-integrity-operator/build/bin /usr/local/bin
 COPY --from=builder /go/src/github.com/openshift/file-integrity-operator/bundle /bundle
 COPY --from=builder /go/src/github.com/openshift/file-integrity-operator/build/guard/libaide_md5_guard.so /opt/libaide_md5_guard.so


### PR DESCRIPTION
Add a `license` directory to the operator image.
This abides to test `HasLicense` from Image Contents Requirements:
https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images