### PR TITLE
Make bundle pipelines runs more restricted

### DIFF
--- a/.tekton/file-integrity-operator-bundle-release-1-3-pull-request.yaml
+++ b/.tekton/file-integrity-operator-bundle-release-1-3-pull-request.yaml
@@ -454,7 +454,7 @@ spec:
         - name: name
           value: sast-coverity-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:34ac8e9ddfaafedaa61a7c3c95d86e674556bfe3da488d94c3bf28fff9875b38
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ed979367665223d0539b11542ac174c37cc7fe85d88f05168d9a7a3177475e
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/file-integrity-operator-bundle-release-1-3-pull-request.yaml
+++ b/.tekton/file-integrity-operator-bundle-release-1-3-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-1.3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.3" &&
+      ("bundle-hack/***".pathChanged() || "bundle/***".pathChanged() || ".tekton/*bundle-release*.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: file-integrity-operator-release-1-3

--- a/.tekton/file-integrity-operator-bundle-release-1-3-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-release-1-3-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-1.3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.3" &&
+      ("bundle-hack/***".pathChanged() || "bundle/***".pathChanged() || ".tekton/*bundle-release*.yaml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: file-integrity-operator-release-1-3

--- a/.tekton/file-integrity-operator-bundle-release-1-3-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-release-1-3-push.yaml
@@ -451,7 +451,7 @@ spec:
         - name: name
           value: sast-coverity-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:34ac8e9ddfaafedaa61a7c3c95d86e674556bfe3da488d94c3bf28fff9875b38
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ed979367665223d0539b11542ac174c37cc7fe85d88f05168d9a7a3177475e
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/file-integrity-operator-release-1-3-pull-request.yaml
+++ b/.tekton/file-integrity-operator-release-1-3-pull-request.yaml
@@ -472,7 +472,7 @@ spec:
         - name: name
           value: sast-coverity-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:34ac8e9ddfaafedaa61a7c3c95d86e674556bfe3da488d94c3bf28fff9875b38
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ed979367665223d0539b11542ac174c37cc7fe85d88f05168d9a7a3177475e
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/file-integrity-operator-release-1-3-push.yaml
+++ b/.tekton/file-integrity-operator-release-1-3-push.yaml
@@ -469,7 +469,7 @@ spec:
         - name: name
           value: sast-coverity-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:34ac8e9ddfaafedaa61a7c3c95d86e674556bfe3da488d94c3bf28fff9875b38
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ed979367665223d0539b11542ac174c37cc7fe85d88f05168d9a7a3177475e
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Only run bundle pipelines when there are changes to bundle relevant files.