### PR TITLE
Nudge the bundle build after #739

### DIFF
--- a/bundle-hack/update_csv.go
+++ b/bundle-hack/update_csv.go
@@ -147,7 +147,7 @@ func replaceImages(csv map[string]interface{}) {
 	// recent builds. We want to peel off the SHA and append it to the Red
 	// Hat registry so that the bundle image will work when it's available
 	// there.
-	konfluxPullSpec := "quay.io/redhat-user-workloads/ocp-isc-tenant/file-integrity-operator-release@sha256:28d1be4d42899671f3f181aeb955d537fe334a78dc41aecd80fdabe3898857fb"
+	konfluxPullSpec := "quay.io/redhat-user-workloads/ocp-isc-tenant/file-integrity-operator-release@sha256:dc0e9a64951fc91009b855a866a022873c61e929aa8461e89fc818f353e2618c"
 	delimiter := "@"
 	parts := strings.Split(konfluxPullSpec, delimiter)
 	if len(parts) > 2 {


### PR DESCRIPTION
Let's reference the latest image operator in the bundle image.

- Last merged PR: https://github.com/openshift/file-integrity-operator/pull/739
- Commit that triggered the event: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/ocp-isc-tenant/applications/file-integrity-operator-release-1-3/commit/c3787af07a461b9e44581194cd3143fc1c2a6d76
- Push pipeline: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/ocp-isc-tenant/applications/file-integrity-operator-release-1-3/pipelineruns/file-integrity-operator-release-1-3-on-push-l9dvn