### PR TITLE
Configure file to nudge after builds

### DIFF
--- a/.tekton/file-integrity-operator-dev-push.yaml
+++ b/.tekton/file-integrity-operator-dev-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: "bundle-hack/update_csv.go"
     build.appstudio.openshift.io/repo: https://github.com/openshift/file-integrity-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
The default value of `".*Dockerfile.*, .*.yaml, .*Containerfile.*"` doesn't suit us.