### PR TITLE
CMP-3539: Configure sast-snyk-check to upload reports to our org

### DIFF
--- a/.tekton/file-integrity-operator-bundle-dev-pull-request.yaml
+++ b/.tekton/file-integrity-operator-bundle-dev-pull-request.yaml
@@ -380,6 +380,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=openshift/file-integrity-operator --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-bundle-dev-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-dev-push.yaml
@@ -377,6 +377,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=openshift/file-integrity-operator --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-dev-pull-request.yaml
+++ b/.tekton/file-integrity-operator-dev-pull-request.yaml
@@ -398,6 +398,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=openshift/file-integrity-operator --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-dev-push.yaml
+++ b/.tekton/file-integrity-operator-dev-push.yaml
@@ -396,6 +396,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=openshift/file-integrity-operator --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
- Configure our pipelines to send reports back to Snyk dashboard