### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for file-integrity-operator-release-1-3

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -32,7 +32,8 @@ LABEL \
         summary="File Integrity Operator" \
         maintainer="Red Hat ISC <isc-team@redhat.com>" \
         License="GPLv2+" \
-        name="openshift-file-integrity-operator" \
+        name="compliance/openshift-file-integrity-rhel8-operator" \
+        cpe="cpe:/a:redhat:openshift_file_integrity_operator:1::el9" \
         com.redhat.component="openshift-file-integrity-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="File Integrity Operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
