### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for file-integrity-operator-bundle-release-1-3

### DIFF
--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -11,7 +11,8 @@ RUN ./update_bundle_annotations.sh
 
 FROM scratch
 
-LABEL name=openshift-file-integrity-operator-bundle
+LABEL name="compliance/openshift-file-integrity-operator-bundle"
+LABEL cpe="cpe:/a:redhat:openshift_file_integrity_operator:1::el9"
 LABEL version=${FIO_NEW_VERSION}
 LABEL summary='OpenShift File Integrity Operator'
 LABEL maintainer='Infrastructure Security and Compliance Team <isc-team@redhat.com>'


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
