### PR TITLE
Add branch as a tag for konflux builds

### DIFF
--- a/.tekton/file-integrity-operator-bundle-dev-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-dev-push.yaml
@@ -546,6 +546,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-dev-push.yaml
+++ b/.tekton/file-integrity-operator-dev-push.yaml
@@ -579,6 +579,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
This makes it easier to fetch the latest container builds based on the
branch.
