### PR TITLE
Add branch as a tag for konflux builds

### DIFF
--- a/.tekton/file-integrity-operator-bundle-release-1-3-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-release-1-3-push.yaml
@@ -546,6 +546,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-release-1-3-push.yaml
+++ b/.tekton/file-integrity-operator-release-1-3-push.yaml
@@ -580,6 +580,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Add branch as a tag for konflux builds
    
This makes it easier to fetch the latest container builds based on the
branch.
    
This is a backport of https://github.com/openshift/file-integrity-operator/pull/795