### PR TITLE
Migrate away from deprecated ioutil

### DIFF
--- a/cmd/manager/daemon_util.go
+++ b/cmd/manager/daemon_util.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -351,19 +349,28 @@ func backupFile(file string) error {
 // Prune the oldest backup files (above max number) created by backupFile()
 func pruneBackupFiles(dirPath, fileName string, max int) error {
 	// find the related backup files
-	files, err := ioutil.ReadDir(dirPath)
+	files, err := os.ReadDir(dirPath)
 	if err != nil {
 		return err
 	}
 
-	backups := []fs.FileInfo{}
-	for i, _ := range files {
-		f := files[i]
+	type backupEntry struct {
+		name    string
+		modTime int64
+	}
+
+	var backups []backupEntry
+	for _, f := range files {
 		if f.IsDir() {
 			continue
 		}
 		if strings.HasPrefix(f.Name(), fmt.Sprintf("%s.backup-", fileName)) {
-			backups = append(backups, files[i])
+			info, err := f.Info()
+			if err != nil {
+				LOG("error reading backup file info: %s", err)
+				continue
+			}
+			backups = append(backups, backupEntry{name: f.Name(), modTime: info.ModTime().Unix()})
 		}
 	}
 
@@ -374,19 +381,19 @@ func pruneBackupFiles(dirPath, fileName string, max int) error {
 
 	// Sort backups oldest first
 	sort.Slice(backups, func(i, j int) bool {
-		return backups[i].ModTime().Unix() < backups[j].ModTime().Unix()
+		return backups[i].modTime < backups[j].modTime
 	})
 
 	// Delete the older entries
 	last := len(backups) - max
-	for i, _ := range backups {
+	for i := range backups {
 		if i < last {
-			removeErr := os.Remove(path.Join(dirPath, backups[i].Name()))
+			removeErr := os.Remove(path.Join(dirPath, backups[i].name))
 			if removeErr != nil {
 				LOG("error removing backup files: %s", removeErr)
 				continue
 			}
-			DBG("pruned backup files - removed %s", path.Join(dirPath, backups[i].Name()))
+			DBG("pruned backup files - removed %s", path.Join(dirPath, backups[i].name))
 		}
 	}
 

--- a/cmd/manager/logcollector.go
+++ b/cmd/manager/logcollector.go
@@ -19,7 +19,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sync"
 	"time"
 )
@@ -98,7 +98,7 @@ func handleFailedResult(ctx context.Context, rt *daemonRuntime, conf *daemonConf
 	// Always read in the contents, when compressed we still need the uncompressed version to figure out
 	// the changed details when updating the configMap later on.
 	r := bufio.NewReader(file)
-	contents, err := ioutil.ReadAll(r)
+	contents, err := io.ReadAll(r)
 	if err != nil {
 		logAndTryReportingDaemonError(ctx, rt, conf, "error reading AIDE log: %v", err)
 		if closeErr := file.Close(); closeErr != nil {

--- a/cmd/manager/logcollector_util.go
+++ b/cmd/manager/logcollector_util.go
@@ -22,7 +22,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"time"
 
@@ -121,7 +120,7 @@ func encodetoBase64(src []byte) string {
 			pw.Close()
 		}
 	}()
-	out, _ := ioutil.ReadAll(pr)
+	out, _ := io.ReadAll(pr)
 	return string(out)
 }
 

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -415,7 +415,7 @@ func fipsModeEnabled() (bool, error) {
 		return false, err
 	}
 
-	d, err := ioutil.ReadAll(f)
+	d, err := io.ReadAll(f)
 	if err != nil {
 		if closeErr := f.Close(); closeErr != nil {
 			return false, closeErr

--- a/pkg/common/var.go
+++ b/pkg/common/var.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -12,7 +11,7 @@ import (
 var ErrNoNamespace = fmt.Errorf("namespace not found for current environment")
 
 var readSAFile = func() ([]byte, error) {
-	return ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	return os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 }
 
 // GetOperatorNamespace returns the namespace the operator should be running in from

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -450,7 +449,7 @@ func replaceNamespaceFromManifest(t *testing.T, nsFrom, nsTo string, namespacedM
 	}
 	manPath := *namespacedManPath
 	// #nosec
-	read, err := ioutil.ReadFile(manPath)
+	read, err := os.ReadFile(manPath)
 	if err != nil {
 		t.Fatalf("Error reading namespaced manifest file: %s", err)
 	}
@@ -458,7 +457,7 @@ func replaceNamespaceFromManifest(t *testing.T, nsFrom, nsTo string, namespacedM
 	newContents := strings.Replace(string(read), nsFrom, nsTo, -1)
 
 	// #nosec
-	err = ioutil.WriteFile(manPath, []byte(newContents), 644)
+	err = os.WriteFile(manPath, []byte(newContents), 0644)
 	if err != nil {
 		t.Fatalf("Error writing namespaced manifest file: %s", err)
 	}

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -5,7 +5,6 @@ import (
 	goctx "context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -246,7 +245,7 @@ func (f *Framework) runM(m *testing.M) (int, error) {
 	}
 
 	// create crd
-	globalYAML, err := ioutil.ReadFile(f.globalManPath)
+	globalYAML, err := os.ReadFile(f.globalManPath)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read global resource manifest: %w", err)
 	}

--- a/tests/framework/projutil.go
+++ b/tests/framework/projutil.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -215,7 +214,7 @@ func GetGoPkg() string {
 	if _, err := os.Stat(goModFile); err != nil && !os.IsNotExist(err) {
 		log.Fatalf("Failed to read go.mod: %v", err)
 	} else if err == nil {
-		b, err := ioutil.ReadFile(goModFile)
+		b, err := os.ReadFile(goModFile)
 		if err != nil {
 			log.Fatalf("Read go.mod: %v", err)
 		}

--- a/tests/framework/resource.go
+++ b/tests/framework/resource.go
@@ -6,7 +6,6 @@ import (
 	goctx "context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -211,7 +210,7 @@ func (ctx *Context) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOp
 
 func (ctx *Context) InitializeClusterResources(cleanupOptions *CleanupOptions) error {
 	// create namespaced resources
-	namespacedYAML, err := ioutil.ReadFile(ctx.namespacedManPath)
+	namespacedYAML, err := os.ReadFile(ctx.namespacedManPath)
 	if err != nil {
 		return fmt.Errorf("failed to read namespaced manifest: %w", err)
 	}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Migration from `ioutil` to `os`/`io`:**

* Replaced `ioutil.ReadFile` and `ioutil.WriteFile` with `os.ReadFile` and `os.WriteFile` in various files, including `pkg/common/var.go`, `tests/e2e/helpers.go`, `tests/framework/framework.go`, `tests/framework/projutil.go`, and `tests/framework/resource.go`. [[1]](diffhunk://#diff-41b2aca96b027a92bf0739c35abb60dfb9ae51a70849931f207b4cd3c431c15bL15-R14) [[2]](diffhunk://#diff-08b492c868be97d16c2f1661fe91390e7bef81ea7345487a247fa767c9e7afe9L453-R460) [[3]](diffhunk://#diff-daae6ec46e067f8e5865824aaec7ba3fb8df5c27c268ce4a00aebe3f139868d4L249-R248) [[4]](diffhunk://#diff-e5cfd785c82cffec118bf1fb9d94faddfb26dd8b3539da1c10623eaff42138a5L218-R217) [[5]](diffhunk://#diff-9143c281d612a9f82dd62ab4f01432d2639c61d41ae534581078154a6fc02209L214-R213)
* Replaced `ioutil.ReadAll` with `io.ReadAll` in functions that read from streams or files, such as in `cmd/manager/logcollector.go`, `cmd/manager/logcollector_util.go`, and `pkg/common/util.go`. [[1]](diffhunk://#diff-a7d70b049619327d4e026cffffc2cb6eb14418bb2ca82756a2bdc30989ec2de8L101-R101) [[2]](diffhunk://#diff-9ebb9b0694e434924bdbdf8c5e840fd92dee8281ceebb59bf89f968effb4c5adL118-R117) [[3]](diffhunk://#diff-a3206732c69662d901d8e5ccf08d084332c8dbfb58c67996b5bb9ec5b6ed4425L418-R418)
* Replaced `ioutil.ReadDir` with `os.ReadDir`, and updated related logic to use `fs.DirEntry` instead of `fs.FileInfo` in `cmd/manager/daemon_util.go`. This required minor changes to how file metadata is accessed. [[1]](diffhunk://#diff-b375cc337270092d63d1d0562b2b691b2cf9220f29d446efa2194148af87e848L286-R290) [[2]](diffhunk://#diff-b375cc337270092d63d1d0562b2b691b2cf9220f29d446efa2194148af87e848L309-R310)

**General code cleanup:**

* Removed unused `ioutil` imports from multiple files across the codebase. [[1]](diffhunk://#diff-b375cc337270092d63d1d0562b2b691b2cf9220f29d446efa2194148af87e848L23) [[2]](diffhunk://#diff-a7d70b049619327d4e026cffffc2cb6eb14418bb2ca82756a2bdc30989ec2de8L22-R22) [[3]](diffhunk://#diff-9ebb9b0694e434924bdbdf8c5e840fd92dee8281ceebb59bf89f968effb4c5adL25) [[4]](diffhunk://#diff-a3206732c69662d901d8e5ccf08d084332c8dbfb58c67996b5bb9ec5b6ed4425L7-R7) [[5]](diffhunk://#diff-41b2aca96b027a92bf0739c35abb60dfb9ae51a70849931f207b4cd3c431c15bL5) [[6]](diffhunk://#diff-08b492c868be97d16c2f1661fe91390e7bef81ea7345487a247fa767c9e7afe9L11) [[7]](diffhunk://#diff-daae6ec46e067f8e5865824aaec7ba3fb8df5c27c268ce4a00aebe3f139868d4L8) [[8]](diffhunk://#diff-e5cfd785c82cffec118bf1fb9d94faddfb26dd8b3539da1c10623eaff42138a5L5) [[9]](diffhunk://#diff-9143c281d612a9f82dd62ab4f01432d2639c61d41ae534581078154a6fc02209L9)

These changes help ensure the project is up to date with Go best practices and ready for future Go releases.