### PR TITLE
Separate build trigger for operator and bundle

### DIFF
--- a/.tekton/file-integrity-operator-bundle-dev-pull-request.yaml
+++ b/.tekton/file-integrity-operator-bundle-dev-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master" && files.all.all(x, x.matches('^bundle/') || x.matches('^bundle-hack/') || x.matches('^bundle\\.openshift\\.Dockerfile') || x.matches('^\\.tekton/file-integrity-operator-bundle-dev-.*\\.yaml'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: file-integrity-operator-dev

--- a/.tekton/file-integrity-operator-bundle-dev-push.yaml
+++ b/.tekton/file-integrity-operator-bundle-dev-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master" && files.all.all(x, x.matches('^bundle/') || x.matches('^bundle-hack/') || x.matches('^bundle\\.openshift\\.Dockerfile') || x.matches('^\\.tekton/file-integrity-operator-bundle-dev-.*\\.yaml'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: file-integrity-operator-dev

--- a/.tekton/file-integrity-operator-dev-pull-request.yaml
+++ b/.tekton/file-integrity-operator-dev-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master" && !files.all.all(x, x.matches('^bundle/') || x.matches('^bundle-hack/') || x.matches('^bundle\\.openshift\\.Dockerfile') || x.matches('^\\.tekton/file-integrity-operator-bundle-dev-.*\\.yaml'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: file-integrity-operator-dev

--- a/.tekton/file-integrity-operator-dev-push.yaml
+++ b/.tekton/file-integrity-operator-dev-push.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master" && !files.all.all(x, x.matches('^bundle/') || x.matches('^bundle-hack/') || x.matches('^bundle\\.openshift\\.Dockerfile') || x.matches('^\\.tekton/file-integrity-operator-bundle-dev-.*\\.yaml'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: file-integrity-operator-dev


### PR DESCRIPTION
Let's not build both images all the time.
This leads to two snapshots whenever there is a build, and makes it a bit more difficult to find the correct one for release.