### PR TITLE
CMP-3954: Restrict gomod updates on release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,22 @@
 {
+  "extends": [
+    "config:recommended"
+  ],
   "labels": ["ok-to-test","px-approved","docs-approved","qe-approved"],
   "schedule": [
       "every weekend"
-  ]
+  ],
+  "gomod": {
+    "packageRules": [
+      {
+        "matchManagers": [
+          "gomod"
+        ],
+        "matchBaseBranches": [
+          "/^release-.*/"
+        ],
+        "enabled": false
+      }
+    ]
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,14 @@
   "extends": [
     "config:recommended"
   ],
-  "labels": ["ok-to-test","px-approved","docs-approved","qe-approved"],
+  "labels": [
+    "ok-to-test",
+    "px-approved",
+    "docs-approved",
+    "qe-approved"
+  ],
   "schedule": [
-      "every weekend"
+    "every weekend"
   ],
   "gomod": {
     "packageRules": [


### PR DESCRIPTION
We are more cautious about updating modules in release branches.