### PR TITLE
Release 1.3.8

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -37,7 +37,7 @@ LABEL \
         com.redhat.component="openshift-file-integrity-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="File Integrity Operator" \
-        version=1.3.7
+        version=1.3.8
 #        io.openshift.build.commit.id=98271bc2812881010146f47e4587dcd449b846bd \
 #        io.openshift.build.source-location=https://github.com/openshift/file-integrity-operator.git \
 #        io.openshift.build.commit.url=https://github.com/openshift/file-integrity-operator.git/commit/98271bc2812881010146f47e4587dcd449b846bd \

--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -1,5 +1,5 @@
-ARG FIO_OLD_VERSION="1.3.6"
-ARG FIO_NEW_VERSION="1.3.7"
+ARG FIO_OLD_VERSION="1.3.7"
+ARG FIO_NEW_VERSION="1.3.8"
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22 as builder
 

--- a/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     createdAt: "2024-11-21T18:02:08Z"
-    olm.skipRange: '>=1.0.0 <1.3.7'
+    olm.skipRange: '>=1.0.0 <1.3.8'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-file-integrity
     operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'
@@ -35,7 +35,7 @@ metadata:
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
     operatorframework.io/os.zos: supported
-  name: file-integrity-operator.v1.3.7
+  name: file-integrity-operator.v1.3.8
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -319,5 +319,5 @@ spec:
   relatedImages:
   - image: quay.io/file-integrity-operator/file-integrity-operator:latest
     name: operator
-  version: 1.3.7
-  replaces: file-integrity-operator.v1.3.6
+  version: 1.3.8
+  replaces: file-integrity-operator.v1.3.7

--- a/catalog/preamble.json
+++ b/catalog/preamble.json
@@ -13,8 +13,8 @@
     "package": "file-integrity-operator",
     "entries": [
         {
-            "name": "file-integrity-operator.v1.3.7",
-            "skipRange": ">=1.0.0 <1.3.7"
+            "name": "file-integrity-operator.v1.3.8",
+            "skipRange": ">=1.0.0 <1.3.8"
         }
     ]
 }

--- a/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    olm.skipRange: '>=1.0.0 <1.3.5-dev'
+    olm.skipRange: '>=1.0.0 <1.3.8'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-file-integrity
     operators.openshift.io/infrastructure-features: '["disconnected", "fips"]'

--- a/version.Makefile
+++ b/version.Makefile
@@ -2,4 +2,4 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
-VERSION?=1.3.7
+VERSION?=1.3.8

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.3.7"
+	Version = "1.3.8"
 )


### PR DESCRIPTION
Tag a new z-stream release to address CVE-2025-7195 and a CMP-3757.