### PR TITLE
CMP-4285: Use lowercase "https" scheme for ServiceMonitor compatibility

### DIFF
--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -394,12 +394,42 @@ func createServiceMonitor(ctx context.Context, cfg *rest.Config, mClient *moncli
 		return nil
 	}
 
-	serverName := fmt.Sprintf("metrics.%s.svc", namespace)
 	serviceMonitor := common.GenerateServiceMonitor(service)
+	configureMetricsEndpoints(serviceMonitor, namespace)
+	_, err = mClient.ServiceMonitors(namespace).Create(ctx, serviceMonitor, metav1.CreateOptions{})
+	if err != nil && !kerr.IsAlreadyExists(err) {
+		return err
+	}
+	if kerr.IsAlreadyExists(err) {
+		currentServiceMonitor, getErr := mClient.ServiceMonitors(namespace).Get(ctx, serviceMonitor.Name,
+			metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		serviceMonitorCopy := currentServiceMonitor.DeepCopy()
+		serviceMonitorCopy.Spec = serviceMonitor.Spec
+		if _, updateErr := mClient.ServiceMonitors(namespace).Update(ctx, serviceMonitorCopy,
+			metav1.UpdateOptions{}); updateErr != nil {
+			return updateErr
+		}
+	}
+	return nil
+}
+
+func configureMetricsEndpoints(serviceMonitor *monitoring.ServiceMonitor, namespace string) {
+	serverName := fmt.Sprintf("metrics.%s.svc", namespace)
 	for i := range serviceMonitor.Spec.Endpoints {
 		if serviceMonitor.Spec.Endpoints[i].Port == metrics.ControllerMetricsServiceName {
 			serviceMonitor.Spec.Endpoints[i].Path = metrics.HandlerPath
-			scheme := monitoring.SchemeHTTPS
+			// Use lowercase "https" instead of
+			// monitoring.SchemeHTTPS ("HTTPS") because
+			// prometheus-operator 0.87.0 relaxed the validation of
+			// this field. Even though we can use HTTPS, we need to
+			// support running on versions of OpenShift with
+			// prometheus-operator that strictly requires "https".
+			// When 0.87.0 is the oldest supported version we can
+			// consider reverting back to using SchemeHTTPS.
+			scheme := monitoring.Scheme("https")
 			serviceMonitor.Spec.Endpoints[i].Scheme = &scheme
 			serviceMonitor.Spec.Endpoints[i].Authorization = &monitoring.SafeAuthorization{
 				Type: "Bearer",
@@ -420,22 +450,4 @@ func createServiceMonitor(ctx context.Context, cfg *rest.Config, mClient *moncli
 			}
 		}
 	}
-	_, err = mClient.ServiceMonitors(namespace).Create(ctx, serviceMonitor, metav1.CreateOptions{})
-	if err != nil && !kerr.IsAlreadyExists(err) {
-		return err
-	}
-	if kerr.IsAlreadyExists(err) {
-		currentServiceMonitor, getErr := mClient.ServiceMonitors(namespace).Get(ctx, serviceMonitor.Name,
-			metav1.GetOptions{})
-		if getErr != nil {
-			return getErr
-		}
-		serviceMonitorCopy := currentServiceMonitor.DeepCopy()
-		serviceMonitorCopy.Spec = serviceMonitor.Spec
-		if _, updateErr := mClient.ServiceMonitors(namespace).Update(ctx, serviceMonitorCopy,
-			metav1.UpdateOptions{}); updateErr != nil {
-			return updateErr
-		}
-	}
-	return nil
 }

--- a/cmd/manager/operator_test.go
+++ b/cmd/manager/operator_test.go
@@ -2,14 +2,43 @@ package manager
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	"github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/fake"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/file-integrity-operator/pkg/common"
+	"github.com/openshift/file-integrity-operator/pkg/controller/metrics"
 )
 
 var _ = Describe("Operator startup tests", func() {
+	Context("ServiceMonitor", func() {
+		It("Uses lowercase https scheme for compatibility with older CRDs", func() {
+			service := &corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-metrics-service",
+					Namespace: "test-ns",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: metrics.ControllerMetricsServiceName},
+					},
+				},
+			}
+			serviceMonitor := common.GenerateServiceMonitor(service)
+			configureMetricsEndpoints(serviceMonitor, "test-ns")
+			for _, ep := range serviceMonitor.Spec.Endpoints {
+				if ep.Port == metrics.ControllerMetricsServiceName {
+					Expect(ep.Scheme).ToNot(BeNil())
+					Expect(string(*ep.Scheme)).To(Equal("https"))
+				}
+			}
+		})
+	})
+
 	Context("PrometheusRule", func() {
 		When("Creating the PrometheusRule", func() {
 			var ctx context.Context


### PR DESCRIPTION
The prometheus-operator constant monitoring.SchemeHTTPS resolves to
uppercase "HTTPS", which is accepted by prometheus-operator >= 0.87.0
but rejected by older CRD versions that only validate lowercase "http"
and "https". This causes the metrics ServiceMonitor to fail creation on
clusters running older prometheus-operator CRDs.

Use monitoring.Scheme("https") instead for compatibility across all
supported OpenShift versions. The endpoint configuration logic is
extracted into configureMetricsEndpoints() with a unit test that will
catch any regression back to SchemeHTTPS.

Relevant upstream change: https://github.com/prometheus-operator/prometheus-operator/pull/8017
