### PR TITLE
Backport #961: Add "compliance" prefix to image name labels

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -30,7 +30,7 @@ LABEL \
         com.redhat.delivery.appregistry="false" \
         maintainer="Red Hat ISC <isc-team@redhat.com>" \
         License="GPLv2+" \
-        name="openshift-file-integrity-operator" \
+        name="compliance/openshift-file-integrity-operator" \
         com.redhat.component="openshift-file-integrity-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="File Integrity Operator" \

--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -20,7 +20,7 @@ FROM scratch
 
 ARG FIO_NEW_VERSION
 
-LABEL name=openshift-file-integrity-operator-bundle
+LABEL name="compliance/openshift-file-integrity-operator-bundle"
 LABEL version=${FIO_NEW_VERSION}
 LABEL summary='OpenShift File Integrity Operator'
 LABEL maintainer='Infrastructure Security and Compliance Team <isc-team@redhat.com>'


### PR DESCRIPTION
OpenShift image name labels must match their name in RHEC Catalog.

Backports #961 to 1.4.