### PR TITLE
CMP-4311: Set cpe label on bundle and operator images

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -31,6 +31,7 @@ LABEL \
         maintainer="Red Hat ISC <isc-team@redhat.com>" \
         License="GPLv2+" \
         name="compliance/openshift-file-integrity-rhel8-operator" \
+        cpe="cpe:/a:redhat:openshift_file_integrity_operator:1::el9" \
         com.redhat.component="openshift-file-integrity-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="File Integrity Operator" \

--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -21,6 +21,7 @@ FROM scratch
 ARG FIO_NEW_VERSION
 
 LABEL name="compliance/openshift-file-integrity-operator-bundle"
+LABEL cpe="cpe:/a:redhat:openshift_file_integrity_operator:1::el9"
 LABEL version=${FIO_NEW_VERSION}
 LABEL summary='OpenShift File Integrity Operator'
 LABEL maintainer='Infrastructure Security and Compliance Team <isc-team@redhat.com>'


### PR DESCRIPTION
Clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

Follow up on master of #758 and #759.