### PR TITLE
Add golangci-lint CI workflow and Makefile target

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,21 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+permissions:
+  contents: read
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+run:
+  timeout: 5m
+  modules-download-mode: vendor
+
+linters:
+  default: standard

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,10 @@ verify: vet gosec ## Run vet and gosec checks.
 gosec: ## Run gosec against code.
 	@$(GO) run github.com/securego/gosec/v2/cmd/gosec -severity medium -confidence medium -quiet $(PKGS)
 
+.PHONY: lint
+lint: ## Run golangci-lint against code.
+	golangci-lint run ./...
+
 CONTROLLER_GEN = $(shell pwd)/build/controller-gen
 controller-gen: ## Build controller-gen from what's in vendor.
 	$(call go-build,./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen)


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow (`golangci-lint.yaml`) that runs golangci-lint on pushes and PRs to master, using `golangci/golangci-lint-action@v9` with golangci-lint v2.12
- Add a `make lint` target for running golangci-lint locally
- Add a minimal `.golangci.yml` config with vendor mode and the standard linter set (errcheck, govet, staticcheck, unused, ineffassign, gosimple)

## Test plan

- [ ] Verify the GitHub Actions workflow triggers on a PR to master
- [x] Run `make lint` locally and confirm it invokes golangci-lint correctly
- [x] Confirm vendor directory is not linted