### PR TITLE
Fix e2e-aws metrics-test PodSecurity violations and flake cascade

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -84,6 +85,14 @@ const (
 	metricsURLFmt   = "https://metrics.%s.svc:8585/"
 	PromethusTestSA = "prometheus-query-sa"
 )
+
+func metricsTestPodOverrides(image string) string {
+	return fmt.Sprintf(`--overrides={"spec":{"securityContext":{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}},"containers":[{"name":"metrics-test","image":"%s","securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}}]}}`, image)
+}
+
+func metricsTestPodOverridesWithSA(image, sa string) string {
+	return fmt.Sprintf(`--overrides={"spec":{"serviceAccountName":"%s","securityContext":{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}},"containers":[{"name":"metrics-test","image":"%s","securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}}]}}`, sa, image)
+}
 
 var mcLabelForWorkerRole = map[string]string{
 	mcWorkerRoleLabelKey: "worker",
@@ -443,21 +452,30 @@ func setupTestRequirements(t *testing.T) *framework.Context {
 	return f
 }
 
+var (
+	originalManifest     []byte
+	originalManifestOnce sync.Once
+)
+
 func replaceNamespaceFromManifest(t *testing.T, nsFrom, nsTo string, namespacedManPath *string) {
 	if namespacedManPath == nil {
 		t.Fatal("Error: no namespaced manifest given as test argument. operator-sdk might have changed.")
 	}
 	manPath := *namespacedManPath
-	// #nosec
-	read, err := os.ReadFile(manPath)
-	if err != nil {
-		t.Fatalf("Error reading namespaced manifest file: %s", err)
-	}
 
-	newContents := strings.Replace(string(read), nsFrom, nsTo, -1)
+	originalManifestOnce.Do(func() {
+		// #nosec
+		data, err := os.ReadFile(manPath)
+		if err != nil {
+			t.Fatalf("Error reading namespaced manifest file: %s", err)
+		}
+		originalManifest = data
+	})
+
+	newContents := strings.Replace(string(originalManifest), nsFrom, nsTo, -1)
 
 	// #nosec
-	err = os.WriteFile(manPath, []byte(newContents), 0644)
+	err := os.WriteFile(manPath, []byte(newContents), 0644)
 	if err != nil {
 		t.Fatalf("Error writing namespaced manifest file: %s", err)
 	}
@@ -2395,9 +2413,10 @@ func logContainerOutput(t *testing.T, f *framework.Framework, namespace, name st
 }
 
 func getMetricResults(t *testing.T, namespace string) string {
+	const image = "registry.fedoraproject.org/fedora-minimal:latest"
 	out := runOCandGetOutput(t, []string{
-		"run", "--rm", "-i", "--restart=Never", "--image=registry.fedoraproject.org/fedora-minimal:latest",
-		"-n" + namespace, "metrics-test", "--", "bash", "-c",
+		"run", "--rm", "-i", "--restart=Never", "--image=" + image,
+		"-n" + namespace, metricsTestPodOverrides(image), "metrics-test", "--", "bash", "-c",
 		getCurlFIOCMD(namespace),
 	})
 
@@ -2406,9 +2425,10 @@ func getMetricResults(t *testing.T, namespace string) string {
 }
 
 func getMetricResultsSupressWarning(t *testing.T, namespace string) string {
+	const image = "registry.fedoraproject.org/fedora-minimal:latest"
 	out := runOCandGetOutputSupressWarning(t, []string{
-		"run", "--rm", "-i", "--restart=Never", "--image=registry.fedoraproject.org/fedora-minimal:latest",
-		"-n" + namespace, "metrics-test", "--", "bash", "-c",
+		"run", "--rm", "-i", "--restart=Never", "--image=" + image,
+		"-n" + namespace, metricsTestPodOverrides(image), "metrics-test", "--", "bash", "-c",
 		getCurlFIOCMD(namespace),
 	})
 
@@ -2468,8 +2488,9 @@ func AssertMetricsEndpointUsesHTTPVersion(t *testing.T, endpoint, version, names
 	// We're just under test.
 	// G204 (CWE-78): Subprocess launched with variable (Confidence: HIGH, Severity: MEDIUM)
 	// #nosec
-	out := runOCandGetOutput(t, []string{"run", "--rm", "-i", "--restart=Never", "--image=registry.fedoraproject.org/fedora-minimal:latest",
-		"-n", namespace, "metrics-test", "--", "bash", "-c", curlCMD})
+	const image = "registry.fedoraproject.org/fedora-minimal:latest"
+	out := runOCandGetOutput(t, []string{"run", "--rm", "-i", "--restart=Never", "--image=" + image,
+		"-n", namespace, metricsTestPodOverrides(image), "metrics-test", "--", "bash", "-c", curlCMD})
 
 	if !strings.Contains(string(out), version) {
 		return fmt.Errorf("metric endpoint is not using %s, got %s", version, out)
@@ -2562,9 +2583,10 @@ func CleanupRBACForMetricsTest(t *testing.T, operatorNamespace string) {
 // GetPrometheusMetricTargets retrieves Prometheus metric targets
 func GetPrometheusMetricTargets(t *testing.T, operatorNamespace string) []promv1.Target {
 	const prometheusCommand = `TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) && { curl -k -s https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091/api/v1/targets --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $TOKEN"; }`
+	const image = "registry.fedoraproject.org/fedora:latest"
 	out := runOCandGetOutput(t, []string{
-		"run", "--rm", "-i", "--restart=Never", "--image=registry.fedoraproject.org/fedora:latest",
-		"-n", operatorNamespace, "--overrides={\"spec\": {\"serviceAccountName\": \"" + PromethusTestSA + "\"}}", "metrics-test", "--", "bash", "-c", prometheusCommand})
+		"run", "--rm", "-i", "--restart=Never", "--image=" + image,
+		"-n", operatorNamespace, metricsTestPodOverridesWithSA(image, PromethusTestSA), "metrics-test", "--", "bash", "-c", prometheusCommand})
 
 	outTrimmed := trimOutput(out)
 	if outTrimmed == "" {

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -2469,34 +2469,30 @@ func runOCandCheckError(t *testing.T, args []string) error {
 	return nil
 }
 
-// runOCGetOutputMaxAttempts and runOCGetOutputRetryDelay bound the retries in runOCandGetOutput.
-// The ephemeral pods it drives routinely hit curl exit 7 (connection refused) when the target
-// service isn't quite ready yet, which is expected and recovers within a few seconds.
-const (
-	runOCGetOutputMaxAttempts = 3
-	runOCGetOutputRetryDelay  = 5 * time.Second
-)
-
 func runOCandGetOutput(t *testing.T, arg []string) string {
 	ocPath := getOCpath(t)
 
 	var out []byte
 	var err error
-	for attempt := 1; attempt <= runOCGetOutputMaxAttempts; attempt++ {
+	// The ephemeral pods this drives routinely hit curl exit 7 (connection refused) while the
+	// target service is still coming up. getMetricResultsSupressWarning tolerates the same
+	// condition via an external wait.Poll using these same pollInterval/pollTimeout constants;
+	// apply it here too instead of failing on the first attempt.
+	_ = wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
 		// We're just under test.
 		// G204 (CWE-78): Subprocess launched with variable (Confidence: HIGH, Severity: MEDIUM)
 		// #nosec
 		cmd := exec.Command(ocPath, arg...)
 		out, err = cmd.CombinedOutput()
-		if err == nil {
-			return string(out)
+		if err != nil {
+			t.Logf("error getting output, retrying: %s", err)
+			return false, nil
 		}
-		t.Logf("attempt %d/%d: error getting output %s", attempt, runOCGetOutputMaxAttempts, err)
-		if attempt < runOCGetOutputMaxAttempts {
-			time.Sleep(runOCGetOutputRetryDelay)
-		}
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("error getting output %s", err)
 	}
-	t.Errorf("error getting output %s", err)
 	return string(out)
 }
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -2469,17 +2469,34 @@ func runOCandCheckError(t *testing.T, args []string) error {
 	return nil
 }
 
+// runOCGetOutputMaxAttempts and runOCGetOutputRetryDelay bound the retries in runOCandGetOutput.
+// The ephemeral pods it drives routinely hit curl exit 7 (connection refused) when the target
+// service isn't quite ready yet, which is expected and recovers within a few seconds.
+const (
+	runOCGetOutputMaxAttempts = 3
+	runOCGetOutputRetryDelay  = 5 * time.Second
+)
+
 func runOCandGetOutput(t *testing.T, arg []string) string {
 	ocPath := getOCpath(t)
 
-	// We're just under test.
-	// G204 (CWE-78): Subprocess launched with variable (Confidence: HIGH, Severity: MEDIUM)
-	// #nosec
-	cmd := exec.Command(ocPath, arg...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Errorf("error getting output %s", err)
+	var out []byte
+	var err error
+	for attempt := 1; attempt <= runOCGetOutputMaxAttempts; attempt++ {
+		// We're just under test.
+		// G204 (CWE-78): Subprocess launched with variable (Confidence: HIGH, Severity: MEDIUM)
+		// #nosec
+		cmd := exec.Command(ocPath, arg...)
+		out, err = cmd.CombinedOutput()
+		if err == nil {
+			return string(out)
+		}
+		t.Logf("attempt %d/%d: error getting output %s", attempt, runOCGetOutputMaxAttempts, err)
+		if attempt < runOCGetOutputMaxAttempts {
+			time.Sleep(runOCGetOutputRetryDelay)
+		}
 	}
+	t.Errorf("error getting output %s", err)
 	return string(out)
 }
 

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -249,7 +249,9 @@ func (f *Framework) runM(m *testing.M) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to read global resource manifest: %w", err)
 	}
-	err = ctx.createFromYAML(globalYAML, true, &CleanupOptions{TestContext: ctx})
+	// replaceIfExists=false: this is one-time global setup (e.g. CRDs); leave any that already
+	// exist alone rather than deleting and recreating them.
+	err = ctx.createFromYAML(globalYAML, false, &CleanupOptions{TestContext: ctx})
 	if err != nil {
 		return 0, fmt.Errorf("failed to create resource(s) in global resource manifest: %w", err)
 	}

--- a/tests/framework/resource.go
+++ b/tests/framework/resource.go
@@ -155,7 +155,28 @@ func (ctx *Context) GetWatchNamespace() (string, error) {
 	return ctx.watchNamespace, nil
 }
 
-func (ctx *Context) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOptions *CleanupOptions) error {
+// createOrReplace creates obj. If it already exists, behavior depends on replaceIfExists:
+// with false, the existing object is left alone (used for one-time global setup, e.g. CRDs,
+// where deleting and recreating would be destructive and pointless). With true, the existing
+// object is deleted and recreated (used for per-test cluster-scoped resources, e.g. a
+// ClusterRole/ClusterRoleBinding left behind by a previous test whose cleanup was skipped
+// after a failure -- leaving it in place would keep it pointed at that deleted namespace's
+// ServiceAccount, silently breaking authorization for every following test).
+func (ctx *Context) createOrReplace(gCtx goctx.Context, obj *unstructured.Unstructured, replaceIfExists bool, cleanupOptions *CleanupOptions) error {
+	err := ctx.client.Create(gCtx, obj, cleanupOptions)
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	if !replaceIfExists {
+		return nil
+	}
+	if delErr := ctx.client.Delete(gCtx, obj); delErr != nil && !apierrors.IsNotFound(delErr) {
+		return fmt.Errorf("failed to delete stale resource before recreating: %w", delErr)
+	}
+	return ctx.client.Create(gCtx, obj, cleanupOptions)
+}
+
+func (ctx *Context) createFromYAML(yamlFile []byte, replaceIfExists bool, cleanupOptions *CleanupOptions) error {
 	operatorNamespace, err := ctx.GetOperatorNamespace()
 	if err != nil {
 		return err
@@ -173,10 +194,7 @@ func (ctx *Context) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOp
 			return fmt.Errorf("failed to unmarshal object spec: %w", err)
 		}
 		obj.SetNamespace(operatorNamespace)
-		err = ctx.client.Create(goctx.TODO(), obj, cleanupOptions)
-		if skipIfExists && apierrors.IsAlreadyExists(err) {
-			continue
-		}
+		err = ctx.createOrReplace(goctx.TODO(), obj, replaceIfExists, cleanupOptions)
 		if err != nil {
 			_, restErr := ctx.restMapper.RESTMappings(obj.GetObjectKind().GroupVersionKind().GroupKind())
 			if restErr == nil {
@@ -192,10 +210,7 @@ func (ctx *Context) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOp
 				}
 				return true, nil
 			})
-			err = ctx.client.Create(goctx.TODO(), obj, cleanupOptions)
-			if skipIfExists && apierrors.IsAlreadyExists(err) {
-				continue
-			}
+			err = ctx.createOrReplace(goctx.TODO(), obj, replaceIfExists, cleanupOptions)
 			if err != nil {
 				return err
 			}
@@ -214,8 +229,8 @@ func (ctx *Context) InitializeClusterResources(cleanupOptions *CleanupOptions) e
 	if err != nil {
 		return fmt.Errorf("failed to read namespaced manifest: %w", err)
 	}
-	// skipIfExists=true tolerates cluster-scoped resources (e.g. the ClusterRole/ClusterRoleBinding)
-	// left behind by a prior test whose cleanup was skipped after a failure, so one failed test
-	// doesn't cascade into every subsequent test in the run.
+	// replaceIfExists=true: delete and recreate any cluster-scoped resource left behind by a
+	// previous test whose cleanup was skipped after a failure, so it's freshly bound to this
+	// test's namespace instead of a stale, since-deleted one.
 	return ctx.createFromYAML(namespacedYAML, true, cleanupOptions)
 }

--- a/tests/framework/resource.go
+++ b/tests/framework/resource.go
@@ -214,5 +214,8 @@ func (ctx *Context) InitializeClusterResources(cleanupOptions *CleanupOptions) e
 	if err != nil {
 		return fmt.Errorf("failed to read namespaced manifest: %w", err)
 	}
-	return ctx.createFromYAML(namespacedYAML, false, cleanupOptions)
+	// skipIfExists=true tolerates cluster-scoped resources (e.g. the ClusterRole/ClusterRoleBinding)
+	// left behind by a prior test whose cleanup was skipped after a failure, so one failed test
+	// doesn't cascade into every subsequent test in the run.
+	return ctx.createFromYAML(namespacedYAML, true, cleanupOptions)
 }


### PR DESCRIPTION
## Summary

Supersedes #1005 — includes all of @parametalol's changes plus one additional fix:

- **Retry logic for `runOCandGetOutput`** — ephemeral metrics pods routinely hit curl exit 7 (connection refused) while the metrics service is coming up; retries with `wait.PollImmediate` instead of failing on the first attempt (from #1005)
- **Replace stale cluster-scoped resources** — `InitializeClusterResources` now deletes and recreates cluster-scoped RBAC objects left behind by a previous test whose cleanup was skipped, instead of hard-failing on "already exists" (from #1005)
- **Add PodSecurity `restricted:latest` security context to `metrics-test` pods** — all four `oc run` call sites now include `--overrides` setting `runAsNonRoot`, `seccompProfile`, `allowPrivilegeEscalation=false`, and `capabilities.drop=["ALL"]` so the ephemeral pods comply with enforced PodSecurity policy

## Test plan

- [x] `go build ./tests/...`
- [x] `go vet ./tests/...`
- [ ] `e2e-aws` Prow job passes

Co-Authored-By: Michaël <github@parameta.lol>

🤖 Generated with [Claude Code](https://claude.com/claude-code)