### PR TITLE
CMP-4460: Include libgcrypt-devel on RPM refreshes

### DIFF
--- a/konflux/rpms.in.yaml
+++ b/konflux/rpms.in.yaml
@@ -5,6 +5,7 @@ contentOrigin:
 packages:
   - tar
   - aide
+  - libgcrypt-devel
 
 arches:
   - x86_64

--- a/konflux/rpms.lock.yaml
+++ b/konflux/rpms.lock.yaml
@@ -4,13 +4,27 @@ lockfileVendor: redhat
 arches:
 - arch: ppc64le
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/a/aide-0.19.2-5.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/a/aide-0.19.2-5.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 163883
-    checksum: sha256:f105fead6ecbb2cdf9d4df6d8a40b943e08bad78600ed2fc9eada9396da0a2bb
+    size: 180195
+    checksum: sha256:6b8d8470fc508791b729ddd4103a472353bd9d557fb5b391f92e323edb56b7b1
     name: aide
-    evr: 0.19.2-5.el9
-    sourcerpm: aide-0.19.2-5.el9.src.rpm
+    evr: 0.19.2-5.el9_8.1
+    sourcerpm: aide-0.19.2-5.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/l/libgcrypt-devel-1.10.0-11.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 153840
+    checksum: sha256:500a0ba8749ac0e1f1da05e8fc5902eb997d68ac04aaf58df4fe6fb8f9a43e70
+    name: libgcrypt-devel
+    evr: 1.10.0-11.el9
+    sourcerpm: libgcrypt-1.10.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/l/libgpg-error-devel-1.42-5.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 73469
+    checksum: sha256:61f850ef9ef573a7a54af88b3e323e8095f0d341dff39b03ac50e928ad1d8f99
+    name: libgpg-error-devel
+    evr: 1.42-5.el9
+    sourcerpm: libgpg-error-1.42-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/e/e2fsprogs-libs-1.46.5-5.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 259223
@@ -18,6 +32,41 @@ arches:
     name: e2fsprogs-libs
     evr: 1.46.5-5.el9
     sourcerpm: e2fsprogs-1.46.5-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 612983
+    checksum: sha256:917a9fc0eca0405813697b4d830578c92b01c1dba766321bfa880a248b0c4d5e
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+    sourcerpm: libgcrypt-1.10.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 42712
+    checksum: sha256:a96600fec79e7d94523816dc620203e812c4a08c82c07fb3bb62d7e9e6e1f661
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 46315
+    checksum: sha256:a70516a3a8f016a80613bc071586cd653db12a650c4c9f057743125cb7ad7433
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 12416
+    checksum: sha256:1d641be62db76b074f4ca2d6b470d85dcf806d96e2c834337482a73984db1979
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/t/tar-1.34-11.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 945887
@@ -26,18 +75,36 @@ arches:
     evr: 2:1.34-11.el9
     sourcerpm: tar-1.34-11.el9.src.rpm
   source:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/a/aide-0.19.2-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/a/aide-0.19.2-5.el9_8.1.src.rpm
     repoid: rhel-9-for-ppc64le-appstream-source-rpms
-    size: 417936
-    checksum: sha256:7f4ac05328b61e6ac36dd2bb9a9990b10898f12a8e4d213f99596407b5676ff0
+    size: 439367
+    checksum: sha256:02f43c0564438bc1c93cde65f49ee747296b6b4c7a7522089eb5997e8b049eb0
     name: aide
-    evr: 0.19.2-5.el9
+    evr: 0.19.2-5.el9_8.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-5.el9.src.rpm
     repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 7417195
     checksum: sha256:d54bf1aa0e66a1e45dceaa7add783b00fc6f958cafa74fe3c7a2986c35f7af4d
     name: e2fsprogs
     evr: 1.46.5-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libgcrypt-1.10.0-11.el9.src.rpm
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
+    size: 3981814
+    checksum: sha256:3ac5b6ac1a4be5513e76fa2f33346014b8b3c5c47bbe71524ce326782b163d2e
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libgpg-error-1.42-5.el9.src.rpm
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
+    size: 994101
+    checksum: sha256:9586046fd9622e5e898f92a08821948bf0754a74ab343cc093ca21caae0352a6
+    name: libgpg-error
+    evr: 1.42-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
+    size: 310904
+    checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
+    name: pkgconf
+    evr: 1.7.3-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/t/tar-1.34-11.el9.src.rpm
     repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 2294162
@@ -47,13 +114,27 @@ arches:
   module_metadata: []
 - arch: s390x
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/a/aide-0.19.2-5.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/a/aide-0.19.2-5.el9_8.1.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 155098
-    checksum: sha256:e8831f64a69c0878195115df73715dde8681e5c38e6b87cd2215be70dc01a057
+    size: 171231
+    checksum: sha256:9aab67a2015bf6e8ed2395456ad718dce686ff53ed50803fa2c720e568305975
     name: aide
-    evr: 0.19.2-5.el9
-    sourcerpm: aide-0.19.2-5.el9.src.rpm
+    evr: 0.19.2-5.el9_8.1
+    sourcerpm: aide-0.19.2-5.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/l/libgcrypt-devel-1.10.0-11.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 151412
+    checksum: sha256:194583641dbac01215baa553eebbe03902ebfbd8f40a265e0da90a88ec3cf930
+    name: libgcrypt-devel
+    evr: 1.10.0-11.el9
+    sourcerpm: libgcrypt-1.10.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/l/libgpg-error-devel-1.42-5.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 70545
+    checksum: sha256:91b172e4284a03a804b8781295612fb5d9ee2bed0c12f04461390541de9898bc
+    name: libgpg-error-devel
+    evr: 1.42-5.el9
+    sourcerpm: libgpg-error-1.42-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/e/e2fsprogs-libs-1.46.5-5.el9.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
     size: 230941
@@ -61,6 +142,41 @@ arches:
     name: e2fsprogs-libs
     evr: 1.46.5-5.el9
     sourcerpm: e2fsprogs-1.46.5-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 469635
+    checksum: sha256:ad73b3b1163668089b5768b0887561960dd3eae21b6d05f3a09fe1dca42920a3
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+    sourcerpm: libgcrypt-1.10.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 37876
+    checksum: sha256:fa1da3b44d85663cceaa0faf8eb5f2f7325cc83c381d6018f303edd06cab5938
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 45258
+    checksum: sha256:a5f966f792cacc4696e4187593a915fb56452dd272cf4c81d930968adb3ee00c
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 12411
+    checksum: sha256:ef854bfe75102d994afb58510121164c4b9b8359b7d983cd8904c425a175b750
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/t/tar-1.34-11.el9.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
     size: 907745
@@ -69,18 +185,36 @@ arches:
     evr: 2:1.34-11.el9
     sourcerpm: tar-1.34-11.el9.src.rpm
   source:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/a/aide-0.19.2-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/a/aide-0.19.2-5.el9_8.1.src.rpm
     repoid: rhel-9-for-s390x-appstream-source-rpms
-    size: 417936
-    checksum: sha256:7f4ac05328b61e6ac36dd2bb9a9990b10898f12a8e4d213f99596407b5676ff0
+    size: 439367
+    checksum: sha256:02f43c0564438bc1c93cde65f49ee747296b6b4c7a7522089eb5997e8b049eb0
     name: aide
-    evr: 0.19.2-5.el9
+    evr: 0.19.2-5.el9_8.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-5.el9.src.rpm
     repoid: rhel-9-for-s390x-baseos-source-rpms
     size: 7417195
     checksum: sha256:d54bf1aa0e66a1e45dceaa7add783b00fc6f958cafa74fe3c7a2986c35f7af4d
     name: e2fsprogs
     evr: 1.46.5-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libgcrypt-1.10.0-11.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 3981814
+    checksum: sha256:3ac5b6ac1a4be5513e76fa2f33346014b8b3c5c47bbe71524ce326782b163d2e
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libgpg-error-1.42-5.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 994101
+    checksum: sha256:9586046fd9622e5e898f92a08821948bf0754a74ab343cc093ca21caae0352a6
+    name: libgpg-error
+    evr: 1.42-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 310904
+    checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
+    name: pkgconf
+    evr: 1.7.3-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/t/tar-1.34-11.el9.src.rpm
     repoid: rhel-9-for-s390x-baseos-source-rpms
     size: 2294162
@@ -90,13 +224,27 @@ arches:
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/aide-0.19.2-5.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/a/aide-0.19.2-5.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 160699
-    checksum: sha256:c4491c58b7314f82776f925892fda9727177fe75e6841f1298677e3133ca5830
+    size: 176407
+    checksum: sha256:1b81dc1ef72dad980318fa0704e19e720823f7f6863457f9a243b0c455c8baa6
     name: aide
-    evr: 0.19.2-5.el9
-    sourcerpm: aide-0.19.2-5.el9.src.rpm
+    evr: 0.19.2-5.el9_8.1
+    sourcerpm: aide-0.19.2-5.el9_8.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libgcrypt-devel-1.10.0-11.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 151880
+    checksum: sha256:01f2174ed9540035f3b5fe2c952ace6fca28bebf0dbb567cd7671db3c6a5e2c8
+    name: libgcrypt-devel
+    evr: 1.10.0-11.el9
+    sourcerpm: libgcrypt-1.10.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libgpg-error-devel-1.42-5.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 70899
+    checksum: sha256:3bbaa1add2e083a43ce0cb9e1c1a35ad8a5e8f2f56280b8f1ab241194acc56d6
+    name: libgpg-error-devel
+    evr: 1.42-5.el9
+    sourcerpm: libgpg-error-1.42-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/e/e2fsprogs-libs-1.46.5-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 230322
@@ -104,6 +252,41 @@ arches:
     name: e2fsprogs-libs
     evr: 1.46.5-5.el9
     sourcerpm: e2fsprogs-1.46.5-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libgcrypt-1.10.0-11.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 522581
+    checksum: sha256:9d5a5a4292a5a345143b632c2764ad8e7b095413f78f5693d29c2ea5e7d37119
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+    sourcerpm: libgcrypt-1.10.0-11.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 38387
+    checksum: sha256:4feae5941b73640bd86b8d506a657cac5b770043db1464fbcd207721b2159dda
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 45675
+    checksum: sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 12438
+    checksum: sha256:9a502d81d73d3303ceb53a06ad7ce525c97117ea64352174a33708bf3429283d
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tar-1.34-11.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 913256
@@ -112,18 +295,36 @@ arches:
     evr: 2:1.34-11.el9
     sourcerpm: tar-1.34-11.el9.src.rpm
   source:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/a/aide-0.19.2-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/a/aide-0.19.2-5.el9_8.1.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
-    size: 417936
-    checksum: sha256:7f4ac05328b61e6ac36dd2bb9a9990b10898f12a8e4d213f99596407b5676ff0
+    size: 439367
+    checksum: sha256:02f43c0564438bc1c93cde65f49ee747296b6b4c7a7522089eb5997e8b049eb0
     name: aide
-    evr: 0.19.2-5.el9
+    evr: 0.19.2-5.el9_8.1
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/e/e2fsprogs-1.46.5-5.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 7417195
     checksum: sha256:d54bf1aa0e66a1e45dceaa7add783b00fc6f958cafa74fe3c7a2986c35f7af4d
     name: e2fsprogs
     evr: 1.46.5-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libgcrypt-1.10.0-11.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 3981814
+    checksum: sha256:3ac5b6ac1a4be5513e76fa2f33346014b8b3c5c47bbe71524ce326782b163d2e
+    name: libgcrypt
+    evr: 1.10.0-11.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libgpg-error-1.42-5.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 994101
+    checksum: sha256:9586046fd9622e5e898f92a08821948bf0754a74ab343cc093ca21caae0352a6
+    name: libgpg-error
+    evr: 1.42-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/p/pkgconf-1.7.3-10.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 310904
+    checksum: sha256:4d53718592b298ca7c49665b1f4e7bd32dcb42cad15c89345585da9f20d4fcae
+    name: pkgconf
+    evr: 1.7.3-10.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/t/tar-1.34-11.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 2294162


### PR DESCRIPTION
- The `libgcrypt-devel` library was missed in https://github.com/openshift/file-integrity-operator/pull/926.
- https://github.com/openshift/file-integrity-operator/pull/993 broke the build on `release-1.4`