### PR TITLE
[master] Add libgcrypt-devel to RPMs lock file

### DIFF
--- a/konflux/rpms.in.yaml
+++ b/konflux/rpms.in.yaml
@@ -5,6 +5,7 @@ contentOrigin:
 packages:
   - tar
   - aide
+  - libgcrypt-devel
 
 arches:
   - x86_64


### PR DESCRIPTION
It is required by build/Dockerfile.openshift.
Was missing in https://github.com/openshift/file-integrity-operator/pull/926