### PR TITLE
make bundle: update all files with specified version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,11 @@ endif
 
 .PHONY: update-skip-range
 update-skip-range: check-operator-version
-	sed -i '/replaces:/d' config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
+	@CURRENT_VERSION=$$(grep '^VERSION?=' version.Makefile | cut -d= -f2); \
+	if [ "$(VERSION)" != "$$CURRENT_VERSION" ]; then \
+		sed -i "s/\(^  replaces: file-integrity-operator.v\).*/\1$$CURRENT_VERSION/" config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml; \
+	fi
+	sed -i "s/\(^  version: \).*/\1$(VERSION)/" config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
 	sed -i "s/\(olm.skipRange: '>=.*\)<.*'/\1<$(VERSION)'/" config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
 	sed -i "s/\(\"name\": \"file-integrity-operator.v\).*\"/\1$(VERSION)\"/" catalog/preamble.json
 	sed -i "s/\(\"skipRange\": \">=.*\)<.*\"/\1<$(VERSION)\"/" catalog/preamble.json
@@ -335,6 +339,14 @@ image: test-unit clean-controller-gen ## Build the operator image.
 
 .PHONY: bundle
 bundle: check-operator-version operator-sdk manifests update-skip-range kustomize ## Generate bundle manifests and metadata, then validate generated files.
+	@CURRENT_VERSION=$$(grep '^VERSION?=' version.Makefile | cut -d= -f2); \
+	if [ "$(VERSION)" != "$$CURRENT_VERSION" ]; then \
+		sed -i "s/^ARG FIO_OLD_VERSION=.*/ARG FIO_OLD_VERSION=\"$$CURRENT_VERSION\"/" bundle.openshift.Dockerfile; \
+		sed -i 's/^ARG FIO_NEW_VERSION=.*/ARG FIO_NEW_VERSION="$(VERSION)"/' bundle.openshift.Dockerfile; \
+	fi
+	sed -i 's/^VERSION?=.*/VERSION?=$(VERSION)/' version.Makefile
+	sed -i 's/Version = ".*"/Version = "$(VERSION)"/' version/version.go
+	sed -i 's/version=.*/version=$(VERSION)/' build/Dockerfile.openshift
 	$(SDK_BIN) generate kustomize manifests --apis-dir=./pkg/apis -q
 	@echo "kustomize using deployment image $(IMG)"
 	cd config/manager && $(KUSTOMIZE) edit set image $(APP_NAME)=$(IMG)


### PR DESCRIPTION
Now, running `make bundle VERSION=x.y.z` bumps all the required files.
Running `make bundle` just regenerates the bundles while keeping the current version.