### PR TITLE
Pin AIDE version to 0.16

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -20,7 +20,7 @@ FROM registry.redhat.io/rhel9-4-els/rhel-minimal:latest
 # without bloating the image.
 RUN export SMDEV_CONTAINER_OFF=1 && \
     microdnf -y update && \
-    microdnf -y install aide tar && microdnf clean all && \
+    microdnf -y install aide-0.16 tar && microdnf clean all && \
     microdnf -y clean all && rm -rf /var/cache/microdnf
 
 LABEL \

--- a/konflux/rpms.in.yaml
+++ b/konflux/rpms.in.yaml
@@ -4,7 +4,7 @@ contentOrigin:
 
 packages:
   - tar
-  - aide
+  - aide-0.16
 
 arches:
   - x86_64


### PR DESCRIPTION
The config we are using in FIO is compatible with AIDE 0.16.

Migrating to 0.18 or 0.19 will require migration steps.