### PR TITLE
Re-Add replaces field to CSV and update Makefile to preserve it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,11 @@ endif
 
 .PHONY: update-skip-range
 update-skip-range: check-operator-version
-	sed -i '/replaces:/d' config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
+	@CURRENT_VERSION=$$(grep '^VERSION?=' version.Makefile | cut -d= -f2); \
+	if [ "$(VERSION)" != "$$CURRENT_VERSION" ]; then \
+		sed -i "s/\(^  replaces: file-integrity-operator.v\).*/\1$$CURRENT_VERSION/" config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml; \
+	fi
+	sed -i "s/\(^  version: \).*/\1$(VERSION)/" config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
 	sed -i "s/\(olm.skipRange: '>=.*\)<.*'/\1<$(VERSION)'/" config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
 	sed -i "s/\(\"name\": \"file-integrity-operator.v\).*\"/\1$(VERSION)\"/" catalog/preamble.json
 	sed -i "s/\(\"skipRange\": \">=.*\)<.*\"/\1<$(VERSION)\"/" catalog/preamble.json

--- a/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/file-integrity-operator.clusterserviceversion.yaml
@@ -327,4 +327,5 @@ spec:
   relatedImages:
   - image: quay.io/file-integrity-operator/file-integrity-operator:latest
     name: operator
+  replaces: file-integrity-operator.v1.4.0
   version: 1.4.1

--- a/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/file-integrity-operator.clusterserviceversion.yaml
@@ -282,4 +282,5 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/openshift/file-integrity-operator
-  version: 0.1.22
+  replaces: file-integrity-operator.v1.4.0
+  version: 1.4.1


### PR DESCRIPTION
The update-skip-range Makefile target was removing the replaces field from the base CSV.

Replace the deletion with a conditional update that automatically sets replaces to the previous version when VERSION changes, and leaves it untouched otherwise.
Also update the base CSV version during bundle generation.