### PR TITLE
CMP-4573: switch runtime base image to ubi9-minimal-pqc

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -12,7 +12,7 @@ COPY . .
 
 RUN make build
 
-FROM registry.redhat.io/rhel9-4-els/rhel-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 # We need tar for the bundle build process to work since it pulls the operator
 # manifests from the operator image using `oc cp`, which will fail if `tar`


### PR DESCRIPTION
## What
Switches the operator's runtime base image in `build/Dockerfile.openshift` from `registry.redhat.io/rhel9-4-els/rhel-minimal:latest` to `registry.redhat.io/ubi9/ubi-minimal-pqc:latest`, per [CMP-4573](https://redhat.atlassian.net/browse/CMP-4573) (epic [CMP-4570](https://redhat.atlassian.net/browse/CMP-4570)).

## Why
`ubi9-minimal-pqc` ships the `DEFAULT:PQ` crypto policy and an OpenSSL 3.5 build with ML-KEM (post-quantum) support, instead of the `DEFAULT` policy and OpenSSL 3.0 on the current base. This is a one-line change; no other files need updating.

## Trade-off: giving up the ELS pinned-minor stability guarantee
`rhel9-4-els` (the current base) is pinned to RHEL **9.4** under Extended Life Cycle Support (ELS) — a paid Red Hat offering that keeps patching that exact minor release for ~6 years instead of rolling forward with normal RHEL 9 minors. `ubi9-minimal-pqc` has no equivalent pinned-minor variant: it only publishes tags on a single rolling `9.8` stream (verified — no `9.4`/`9.6` PQC tag exists). Switching to it means trading that frozen, long-committed minor-version stability for a base that will drift forward whenever Red Hat updates `:latest`.

This is unavoidable if PQC support is the goal — there is no way to keep the ELS pin and get PQC in the same image — but reviewers should be aware it's a real, accepted consequence of this change, not just a base-image rename. Coordinated with the team switching Security Profiles Operator ([CMP-4572](https://redhat.atlassian.net/browse/CMP-4572)), which currently uses the identical `rhel9-4-els/rhel-minimal:latest` base and faces the same trade-off.

## Why `aide`/`tar` availability isn't affected
`aide` is not present in `ubi9-minimal-pqc`'s own baked-in repo (same is true of plain `ubi9-minimal` and, in fact, of `rhel9-4-els/rhel-minimal` itself when pulled standalone outside the build system — it ships with zero configured repos). In production, `aide`/`tar` are installed via the existing Konflux hermetic RPM prefetch (`konflux/rpms.lock.yaml` + `rpms.in.yaml`, `prefetch-input: [{"type": "rpm", "path": "konflux"}]` in the `.tekton` pipelines), which bind-mounts a Cachi2/Hermeto-generated repo directly over `/etc/yum.repos.d` at build time, sourced from the full entitled RHEL9 CDN independent of the runtime base image identity. **No changes to the lockfile are needed for this ticket.**

I compared `aide`'s full dependency closure (`libcurl`, `openssl-libs`, `libselinux`, `audit-libs`, `libacl`, `libattr`, `libcap-ng`, `krb5-libs`, `keyutils-libs`, `e2fsprogs-libs`, `glibc`, `zlib`, `pcre`/`pcre2`) against both base images' default package sets — everything aide needs is already present by default on `ubi9-minimal-pqc`, matching the current base (openssl-libs is deliberately newer, 3.5.x vs 3.0.x — that's the whole point of the PQC image).

## Testing performed
- Built the modified image locally and confirmed `aide --init`/`--check` work correctly and `libaide_md5_guard.so` resolves/loads with no ABI issues (it has no direct link dependency on libgcrypt — symbols are resolved via `dlsym` at runtime).
- Deployed the built image to a live OpenShift 4.22 cluster in place of the running operator.
- Created a `FileIntegrity` CR; confirmed it reaches `Active` with all node `FileIntegrityNodeStatus` objects `Succeeded` (full RHCOS `aide.conf.rhel8`, ~41k tracked entries per node).
- Deliberately modified a tracked file (`/etc/hostname`) on a node; confirmed the operator correctly detected and reported the change (`condition: Failed`, exact SHA512 diff in the result ConfigMap), then confirmed recovery back to `Succeeded` after reverting.
- Confirmed `DEFAULT:PQ` crypto policy active in the running container (`/etc/crypto-policies/state/current`).
- Ran the e2e suite's `TestFileIntegrityLogAndReinitDatabase` against the built image — passed.
